### PR TITLE
Fix the release to use the vX.Y.Z for docker builds and upgrade SLSA generator

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,9 +172,9 @@ jobs:
         with:
           images: ghcr.io/${{ matrix.variant.image-repository }}
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.extract-version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.extract-version.outputs.version }}
-            type=semver,pattern={{major}},value=${{ needs.extract-version.outputs.version }}
+            type=raw,value=${{ needs.extract-version.outputs.tag-name }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ needs.extract-version.outputs.tag-name }}
+            type=semver,pattern=v{{major}},value=${{ needs.extract-version.outputs.tag-name }}
             type=raw,value=${{ matrix.variant.latest_tag }}
             type=raw,value=sha-${{ needs.extract-version.outputs.short-sha }}
           flavor: |

--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -74,7 +74,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
Fix the release to use the vX.Y.Z for docker builds and upgrade SLSA generator