### PR TITLE
Major: rename CRD Bind9GlobalCluster to ClusterBind9Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2025-12-23 23:30] - Breaking: Rename Bind9GlobalCluster to ClusterBind9Provider
+
+**Author:** Erick Bourgeois
+
+### Changed
+- **API Breaking Change**: Renamed CRD kind from `Bind9GlobalCluster` to `ClusterBind9Provider`
+  - `src/crd.rs`: Renamed struct from `Bind9GlobalCluster` to `ClusterBind9Provider`
+  - `src/crd.rs`: Renamed spec struct from `Bind9GlobalClusterSpec` to `ClusterBind9ProviderSpec`
+  - `src/crd.rs`: Updated CRD shortnames from `b9gc`, `b9gcs` to `cb9p`, `cb9ps`
+  - `src/constants.rs`: Renamed constant from `KIND_BIND9_GLOBALCLUSTER` to `KIND_CLUSTER_BIND9_PROVIDER`
+  - `src/labels.rs`: Renamed constant from `MANAGED_BY_BIND9_GLOBAL_CLUSTER` to `MANAGED_BY_CLUSTER_BIND9_PROVIDER`
+  - `src/reconcilers/`: Renamed `bind9globalcluster.rs` to `clusterbind9provider.rs`
+  - `src/reconcilers/`: Renamed `bind9globalcluster_tests.rs` to `clusterbind9provider_tests.rs`
+  - `src/reconcilers/mod.rs`: Updated exports to use new function names
+  - `src/main.rs`: Updated controller registration and wrapper functions
+  - All reconcilers updated to use new type names
+- **Field Rename**: Changed DNSZone field from `globalClusterRef` to `clusterProviderRef`
+  - `src/crd.rs`: Updated DNSZoneSpec field name
+  - All reconcilers updated to use new field name
+- **CRD Files**: Regenerated all CRD YAML files
+  - `deploy/crds/clusterbind9providers.crd.yaml`: New file (replaces bind9globalclusters.crd.yaml)
+  - `deploy/crds/bind9globalclusters.crd.yaml`: Deleted (replaced by clusterbind9providers.crd.yaml)
+  - `deploy/crds/dnszones.crd.yaml`: Regenerated with new field name
+- **Examples**: Updated all example YAML files
+  - `examples/bind9-cluster.yaml`: Updated to use ClusterBind9Provider kind
+  - `examples/dns-zone.yaml`: Updated to use clusterProviderRef field
+  - `examples/multi-tenancy.yaml`: Updated all references
+- **Documentation**: Updated all documentation
+  - `docs/src/concepts/`: Renamed `bind9globalcluster.md` to `clusterbind9provider.md`
+  - Updated 11 documentation files with new terminology
+  - `docs/src/SUMMARY.md`: Updated to reference new filename
+- **RBAC**: Updated role definitions
+  - `deploy/rbac/role.yaml`: Updated resource name from `bind9globalclusters` to `clusterbind9providers`
+  - `deploy/rbac/role-admin.yaml`: Updated resource name from `bind9globalclusters` to `clusterbind9providers`
+
+### Why
+The new naming better reflects the resource's purpose and scope:
+- **Explicit Scope**: "Cluster" prefix clarifies this is a cluster-scoped resource (not namespace-scoped)
+- **Provider Semantics**: "Provider" better describes that it provides BIND9 DNS infrastructure
+- **Consistency**: Aligns with Kubernetes naming conventions (e.g., ClusterRole, ClusterRoleBinding)
+
+### Impact
+- [x] **Breaking change** - Requires manual migration
+- [ ] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
+### Migration Steps
+1. Export existing Bind9GlobalCluster resources: `kubectl get bind9globalclusters -o yaml > backup.yaml`
+2. Update CRDs: `kubectl replace --force -f deploy/crds/`
+3. Update backed up YAML files:
+   - Change `kind: Bind9GlobalCluster` to `kind: ClusterBind9Provider`
+   - Change `globalClusterRef:` to `clusterProviderRef:` in DNSZone resources
+4. Apply updated resources: `kubectl apply -f backup.yaml`
+
 ## [2025-12-23 22:00] - CI/CD: Migrate Workflows to firestoned/github-actions
 
 **Author:** Erick Bourgeois

--- a/deploy/crds/bind9clusters.crd.yaml
+++ b/deploy/crds/bind9clusters.crd.yaml
@@ -36,7 +36,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Bind9Cluster defines a namespace-scoped logical grouping of BIND9 DNS server instances. Use this for tenant-managed DNS infrastructure isolated to a specific namespace. For platform-managed cluster-wide DNS, use Bind9GlobalCluster instead.
+        description: Bind9Cluster defines a namespace-scoped logical grouping of BIND9 DNS server instances. Use this for tenant-managed DNS infrastructure isolated to a specific namespace. For platform-managed cluster-wide DNS, use ClusterBind9Provider instead.
         properties:
           spec:
             description: |-
@@ -46,7 +46,7 @@ spec:
               DNS infrastructure within their namespace. Each team can manage their own cluster
               independently, with RBAC controlling who can create and manage resources.
 
-              For platform-managed, cluster-wide DNS infrastructure, use `Bind9GlobalCluster` instead.
+              For platform-managed, cluster-wide DNS infrastructure, use `ClusterBind9Provider` instead.
 
               # Use Cases
 

--- a/deploy/crds/bind9instances.crd.yaml
+++ b/deploy/crds/bind9instances.crd.yaml
@@ -1389,7 +1389,7 @@ spec:
 
                   Can reference either:
                   - A namespace-scoped `Bind9Cluster` (must be in the same namespace as this instance)
-                  - A cluster-scoped `Bind9GlobalCluster` (cluster-wide, accessible from any namespace)
+                  - A cluster-scoped `ClusterBind9Provider` (cluster-wide, accessible from any namespace)
 
                   The cluster provides shared configuration and defines the logical grouping.
                   The controller will automatically detect whether this references a namespace-scoped

--- a/deploy/crds/clusterbind9providers.crd.yaml
+++ b/deploy/crds/clusterbind9providers.crd.yaml
@@ -7,17 +7,17 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: bind9globalclusters.bindy.firestoned.io
+  name: clusterbind9providers.bindy.firestoned.io
 spec:
   group: bindy.firestoned.io
   names:
     categories: []
-    kind: Bind9GlobalCluster
-    plural: bind9globalclusters
+    kind: ClusterBind9Provider
+    plural: clusterbind9providers
     shortNames:
-    - b9gc
-    - b9gcs
-    singular: bind9globalcluster
+    - cb9p
+    - cb9ps
+    singular: clusterbind9provider
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -36,17 +36,17 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Bind9GlobalCluster defines a cluster-scoped logical grouping of BIND9 DNS server instances. Use this for platform-managed DNS infrastructure accessible from all namespaces. For tenant-managed namespace-scoped DNS, use Bind9Cluster instead.
+        description: ClusterBind9Provider defines a cluster-scoped BIND9 DNS provider that manages DNS infrastructure accessible from all namespaces. Use this for platform-managed DNS infrastructure. For tenant-managed namespace-scoped DNS, use Bind9Cluster instead.
         properties:
           spec:
             description: |-
-              `Bind9GlobalCluster` - Cluster-scoped DNS infrastructure for platform teams.
+              `ClusterBind9Provider` - Cluster-scoped BIND9 DNS provider for platform teams.
 
-              A cluster-scoped cluster allows platform teams to provide shared BIND9 DNS infrastructure
+              A cluster-scoped provider allows platform teams to provision shared BIND9 DNS infrastructure
               that is accessible from any namespace. This is ideal for shared services, production DNS,
               or platform-managed infrastructure that multiple teams use.
 
-              `DNSZones` in any namespace can reference a `Bind9GlobalCluster` using the `globalClusterRef` field.
+              `DNSZones` in any namespace can reference a `ClusterBind9Provider` using the `clusterProviderRef` field.
 
               # Use Cases
 
@@ -58,7 +58,7 @@ spec:
 
               ```yaml
               apiVersion: bindy.firestoned.io/v1alpha1
-              kind: Bind9GlobalCluster
+              kind: ClusterBind9Provider
               metadata:
                 name: shared-production-dns
                 # No namespace - cluster-scoped
@@ -1639,11 +1639,11 @@ spec:
                 description: |-
                   Namespace where `Bind9Instance` resources will be created
 
-                  Since `Bind9GlobalCluster` is cluster-scoped, instances need to be created in a specific namespace.
+                  Since `ClusterBind9Provider` is cluster-scoped, instances need to be created in a specific namespace.
                   Typically this would be a platform-managed namespace like `dns-system`.
 
                   All managed instances (primary and secondary) will be created in this namespace.
-                  `DNSZones` from any namespace can reference this global cluster via `globalClusterRef`.
+                  `DNSZones` from any namespace can reference this provider via `clusterProviderRef`.
 
                   **Default:** If not specified, instances will be created in the same namespace where the
                   Bindy operator is running (from `POD_NAMESPACE` environment variable).
@@ -3539,7 +3539,7 @@ spec:
             type: object
         required:
         - spec
-        title: Bind9GlobalCluster
+        title: ClusterBind9Provider
         type: object
     served: true
     storage: true

--- a/deploy/crds/dnszones.crd.yaml
+++ b/deploy/crds/dnszones.crd.yaml
@@ -29,8 +29,8 @@ spec:
     - jsonPath: .spec.clusterRef
       name: Cluster
       type: string
-    - jsonPath: .spec.globalClusterRef
-      name: Global Cluster
+    - jsonPath: .spec.clusterProviderRef
+      name: Provider
       type: string
     - jsonPath: .spec.ttl
       name: TTL
@@ -41,7 +41,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DNSZone represents an authoritative DNS zone managed by BIND9. Each DNSZone defines a zone (e.g., example.com) with SOA record parameters. Can reference either a namespace-scoped Bind9Cluster or cluster-scoped Bind9GlobalCluster.
+        description: DNSZone represents an authoritative DNS zone managed by BIND9. Each DNSZone defines a zone (e.g., example.com) with SOA record parameters. Can reference either a namespace-scoped Bind9Cluster or cluster-scoped ClusterBind9Provider.
         properties:
           spec:
             description: |-
@@ -53,9 +53,9 @@ spec:
 
               `DNSZones` can reference either:
               - A namespace-scoped `Bind9Cluster` (using `clusterRef`)
-              - A cluster-scoped `Bind9GlobalCluster` (using `globalClusterRef`)
+              - A cluster-scoped `ClusterBind9Provider` (using `clusterProviderRef`)
 
-              Exactly one of `clusterRef` or `globalClusterRef` must be specified.
+              Exactly one of `clusterRef` or `clusterProviderRef` must be specified.
 
               # Example: Namespace-scoped Cluster
 
@@ -89,7 +89,7 @@ spec:
                 namespace: production
               spec:
                 zoneName: example.com
-                globalClusterRef: shared-production-dns  # References Bind9GlobalCluster (cluster-scoped)
+                clusterProviderRef: shared-production-dns  # References ClusterBind9Provider (cluster-scoped)
                 soaRecord:
                   primaryNs: ns1.example.com.
                   adminEmail: admin.example.com.
@@ -101,6 +101,16 @@ spec:
                 ttl: 3600
               ```
             properties:
+              clusterProviderRef:
+                description: |-
+                  Reference to a cluster-scoped `ClusterBind9Provider`.
+
+                  Must match the name of a `ClusterBind9Provider` resource (cluster-scoped).
+                  The zone will be added to all instances in this provider.
+
+                  Either `clusterRef` or `clusterProviderRef` must be specified (not both).
+                nullable: true
+                type: string
               clusterRef:
                 description: |-
                   Reference to a namespace-scoped `Bind9Cluster` in the same namespace.
@@ -108,17 +118,7 @@ spec:
                   Must match the name of a `Bind9Cluster` resource in the same namespace.
                   The zone will be added to all instances in this cluster.
 
-                  Either `clusterRef` or `globalClusterRef` must be specified (not both).
-                nullable: true
-                type: string
-              globalClusterRef:
-                description: |-
-                  Reference to a cluster-scoped `Bind9GlobalCluster`.
-
-                  Must match the name of a `Bind9GlobalCluster` resource (cluster-scoped).
-                  The zone will be added to all instances in this global cluster.
-
-                  Either `clusterRef` or `globalClusterRef` must be specified (not both).
+                  Either `clusterRef` or `clusterProviderRef` must be specified (not both).
                 nullable: true
                 type: string
               nameServerIps:

--- a/deploy/rbac/role-admin.yaml
+++ b/deploy/rbac/role-admin.yaml
@@ -23,9 +23,9 @@ rules:
     resources: ["bind9clusters"]
     verbs: ["delete", "deletecollection"]
 
-  # Bind9GlobalCluster - admin delete permission
+  # ClusterBind9Provider - admin delete permission
   - apiGroups: ["bindy.firestoned.io"]
-    resources: ["bind9globalclusters"]
+    resources: ["clusterbind9providers"]
     verbs: ["delete", "deletecollection"]
 
   # DNSZone - admin delete permission

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -22,13 +22,13 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
     # Permissions needed:
     # - "get", "list", "watch": Read clusters for status updates
-    # - "create": Create clusters for Bind9GlobalCluster
+    # - "create": Create clusters for ClusterBind9Provider
     # - "update", "patch": Update cluster configuration
-    # - "delete": Clean up clusters (Bind9GlobalCluster finalizer cleanup)
+    # - "delete": Clean up clusters (ClusterBind9Provider finalizer cleanup)
 
-  # Bind9GlobalCluster resources - cluster-scoped, NO DELETE (least privilege)
+  # ClusterBind9Provider resources - cluster-scoped, NO DELETE (least privilege)
   - apiGroups: ["bindy.firestoned.io"]
-    resources: ["bind9globalclusters", "bind9globalclusters/status"]
+    resources: ["clusterbind9providers", "clusterbind9providers/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
     # Removed: "delete" - Use bindy-admin-role for deletions
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,7 +16,7 @@
   - [Architecture Diagrams](./concepts/architecture-diagrams.md)
   - [Custom Resource Definitions](./concepts/crds.md)
   - [Bind9Cluster](./concepts/bind9cluster.md)
-  - [Bind9GlobalCluster](./concepts/bind9globalcluster.md)
+  - [ClusterBind9Provider](./concepts/clusterbind9provider.md)
   - [Bind9Instance](./concepts/bind9instance.md)
   - [DNSZone](./concepts/dnszone.md)
   - [DNS Records](./concepts/records.md)

--- a/docs/src/advanced/coredns-replacement.md
+++ b/docs/src/advanced/coredns-replacement.md
@@ -1,6 +1,6 @@
-# Replacing CoreDNS with Bind9GlobalCluster
+# Replacing CoreDNS with ClusterBind9Provider
 
-`Bind9GlobalCluster` provides a powerful alternative to CoreDNS for cluster-wide DNS infrastructure. This guide explores using Bindy as a CoreDNS replacement in Kubernetes clusters.
+`ClusterBind9Provider` provides a powerful alternative to CoreDNS for cluster-wide DNS infrastructure. This guide explores using Bindy as a CoreDNS replacement in Kubernetes clusters.
 
 ## Why Consider Replacing CoreDNS?
 
@@ -32,11 +32,11 @@ CoreDNS is the default DNS solution for Kubernetes, but you might want an altern
 - Limited declarative management
 - Manual ConfigMap edits for changes
 
-### Bindy with Bind9GlobalCluster
+### Bindy with ClusterBind9Provider
 
 ```
 ┌──────────────────────────────────────────────────┐
-│ Bind9GlobalCluster (cluster-scoped)             │
+│ ClusterBind9Provider (cluster-scoped)             │
 │ - Cluster-wide DNS infrastructure                │
 │ - Platform team managed                          │
 └──────────────────────────────────────────────────┘
@@ -64,7 +64,7 @@ Replace CoreDNS with a platform-managed DNS service accessible to all namespaces
 
 ```yaml
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 metadata:
   name: platform-dns
   labels:
@@ -104,7 +104,7 @@ Use Bindy for application DNS while keeping CoreDNS for `cluster.local`:
 # Bindy handles application-specific zones
 
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 metadata:
   name: app-dns
 spec:
@@ -121,7 +121,7 @@ metadata:
   namespace: platform
 spec:
   zoneName: internal.example.com
-  globalClusterRef: app-dns
+  clusterProviderRef: app-dns
   soaRecord:
     primaryNs: ns1.internal.example.com.
     adminEmail: platform.example.com.
@@ -139,7 +139,7 @@ Provide DNS for service mesh configurations:
 
 ```yaml
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 metadata:
   name: mesh-dns
   labels:
@@ -164,7 +164,7 @@ metadata:
   namespace: api-team
 spec:
   zoneName: api.mesh.local
-  globalClusterRef: mesh-dns
+  clusterProviderRef: mesh-dns
 ---
 # Dynamic service records
 apiVersion: bindy.firestoned.io/v1alpha1
@@ -190,10 +190,10 @@ spec:
 
 Run Bindy alongside CoreDNS during migration:
 
-1. **Deploy Bindy Global Cluster**:
+1. **Deploy Bindy Cluster Provider**:
    ```yaml
    apiVersion: bindy.firestoned.io/v1alpha1
-   kind: Bind9GlobalCluster
+   kind: ClusterBind9Provider
    metadata:
      name: platform-dns-migration
    spec:
@@ -259,7 +259,7 @@ Keep CoreDNS for cluster.local, migrate application zones:
      namespace: platform
    spec:
      zoneName: apps.example.com
-     globalClusterRef: platform-dns
+     clusterProviderRef: platform-dns
    ```
 
 3. **Configure Forwarding** (CoreDNS → Bindy):
@@ -284,7 +284,7 @@ For cluster DNS replacement, configure these settings:
 
 ```yaml
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 metadata:
   name: cluster-dns
 spec:
@@ -329,7 +329,7 @@ metadata:
   namespace: dns-system
 spec:
   zoneName: cluster.local
-  globalClusterRef: cluster-dns
+  clusterProviderRef: cluster-dns
   soaRecord:
     primaryNs: ns1.cluster.local.
     adminEmail: dns-admin.cluster.local.
@@ -341,7 +341,7 @@ metadata:
   namespace: dns-system
 spec:
   zoneName: svc.cluster.local
-  globalClusterRef: cluster-dns
+  clusterProviderRef: cluster-dns
   soaRecord:
     primaryNs: ns1.svc.cluster.local.
     adminEmail: dns-admin.svc.cluster.local.
@@ -371,7 +371,7 @@ data:
 ```yaml
 # Infrastructure as code
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 # ... declarative specs
 ---
 apiVersion: bindy.firestoned.io/v1alpha1
@@ -399,7 +399,7 @@ kind: DNSZone
 - Platform team controls everything
 
 **Bindy:**
-- Platform team: Manages `Bind9GlobalCluster`
+- Platform team: Manages `ClusterBind9Provider`
 - Application teams: Manage `DNSZone` and records in their namespace
 - RBAC-enforced isolation
 
@@ -439,7 +439,7 @@ kind: DNSZone
 
 ```yaml
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 metadata:
   name: ha-dns
 spec:
@@ -543,7 +543,7 @@ kubectl get arecords,cnamerecords,mxrecords -A -o yaml > dns-records-backup.yaml
 
 ## Conclusion
 
-`Bind9GlobalCluster` provides a powerful, enterprise-grade alternative to CoreDNS for Kubernetes clusters. While CoreDNS remains an excellent choice for simple forwarding scenarios, Bindy excels when you need:
+`ClusterBind9Provider` provides a powerful, enterprise-grade alternative to CoreDNS for Kubernetes clusters. While CoreDNS remains an excellent choice for simple forwarding scenarios, Bindy excels when you need:
 
 - Declarative DNS infrastructure-as-code
 - GitOps workflows for DNS management
@@ -557,6 +557,6 @@ kubectl get arecords,cnamerecords,mxrecords -A -o yaml > dns-records-backup.yaml
 ## Next Steps
 
 - [Multi-Tenancy Guide](../guide/multi-tenancy.md) - RBAC setup for platform and application teams
-- [Choosing a Cluster Type](../guide/choosing-cluster-type.md) - When to use Bind9GlobalCluster vs Bind9Cluster
+- [Choosing a Cluster Type](../guide/choosing-cluster-type.md) - When to use ClusterBind9Provider vs Bind9Cluster
 - [High Availability](./ha.md) - HA configuration for production DNS
 - [DNSSEC](./dnssec.md) - Enabling DNSSEC for secure DNS

--- a/docs/src/compliance/overview.md
+++ b/docs/src/compliance/overview.md
@@ -122,7 +122,7 @@ As a critical DNS infrastructure component in financial services, Bindy must mee
 
 **Key Controls:**
 - ✅ Controller has minimal required permissions (create/delete secrets for RNDC lifecycle, delete managed resources for finalizer cleanup)
-- ✅ Controller cannot delete user resources (DNSZone, Records, Bind9GlobalCluster - least privilege)
+- ✅ Controller cannot delete user resources (DNSZone, Records, ClusterBind9Provider - least privilege)
 - ✅ Automated RBAC verification script (CI/CD)
 - ✅ Separation of duties (2+ reviewers for code changes)
 

--- a/docs/src/compliance/pci-dss.md
+++ b/docs/src/compliance/pci-dss.md
@@ -184,7 +184,7 @@ gh run list --workflow ci.yaml --limit 100
 # ✅ Controller can CREATE/DELETE secrets (RNDC key lifecycle only)
 # ✅ Controller CANNOT UPDATE/PATCH secrets (immutable pattern)
 # ✅ Controller can DELETE managed resources (Bind9Instance, Bind9Cluster, finalizer cleanup)
-# ✅ Controller CANNOT DELETE user resources (DNSZone, Records, Bind9GlobalCluster)
+# ✅ Controller CANNOT DELETE user resources (DNSZone, Records, ClusterBind9Provider)
 ```
 
 **Secret Access Monitoring:**

--- a/docs/src/compliance/sox-404.md
+++ b/docs/src/compliance/sox-404.md
@@ -108,7 +108,7 @@ gh run list --workflow ci.yaml --limit 50
 # ✅ Controller can create/delete secrets (RNDC key lifecycle)
 # ✅ Controller CANNOT update/patch secrets (immutable pattern)
 # ✅ Controller can delete managed resources (Bind9Instance, Bind9Cluster, finalizer cleanup)
-# ✅ Controller CANNOT delete user resources (DNSZone, Records, Bind9GlobalCluster)
+# ✅ Controller CANNOT delete user resources (DNSZone, Records, ClusterBind9Provider)
 ```
 
 **Evidence for Auditors:**

--- a/docs/src/reference/api.md
+++ b/docs/src/reference/api.md
@@ -28,14 +28,14 @@ This document describes the Custom Resource Definitions (CRDs) provided by Bindy
 
 **API Version**: `bindy.firestoned.io/v1alpha1`
 
-DNSZone represents an authoritative DNS zone managed by BIND9. Each DNSZone defines a zone (e.g., example.com) with SOA record parameters. Can reference either a namespace-scoped Bind9Cluster or cluster-scoped Bind9GlobalCluster.
+DNSZone represents an authoritative DNS zone managed by BIND9. Each DNSZone defines a zone (e.g., example.com) with SOA record parameters. Can reference either a namespace-scoped Bind9Cluster or cluster-scoped ClusterBind9Provider.
 
 #### Spec Fields
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `clusterRef` | string | No | Reference to a namespace-scoped \`Bind9Cluster\` in the same namespace.  Must match the name of a \`Bind9Cluster\` resource in the same namespace. The zone will be added to all instances in this cluster.  Either \`clusterRef\` or \`globalClusterRef\` must be specified (not both). |
-| `globalClusterRef` | string | No | Reference to a cluster-scoped \`Bind9GlobalCluster\`.  Must match the name of a \`Bind9GlobalCluster\` resource (cluster-scoped). The zone will be added to all instances in this global cluster.  Either \`clusterRef\` or \`globalClusterRef\` must be specified (not both). |
+| `clusterRef` | string | No | Reference to a namespace-scoped \`Bind9Cluster\` in the same namespace.  Must match the name of a \`Bind9Cluster\` resource in the same namespace. The zone will be added to all instances in this cluster.  Either \`clusterRef\` or \`clusterProviderRef\` must be specified (not both). |
+| `clusterProviderRef` | string | No | Reference to a cluster-scoped \`ClusterBind9Provider\`.  Must match the name of a \`ClusterBind9Provider\` resource (cluster-scoped). The zone will be added to all instances in this cluster provider.  Either \`clusterRef\` or \`clusterProviderRef\` must be specified (not both). |
 | `nameServerIps` | object | No | Map of nameserver hostnames to IP addresses for glue records.  Glue records provide IP addresses for nameservers within the zone's own domain. This is necessary when delegating subdomains where the nameserver is within the delegated zone itself.  Example: When delegating \`sub.example.com\` with nameserver \`ns1.sub.example.com\`, you must provide the IP address of \`ns1.sub.example.com\` as a glue record.  Format: \`{"ns1.example.com.": "192.0.2.1", "ns2.example.com.": "192.0.2.2"}\`  Note: Nameserver hostnames should end with a dot (.) for FQDN. |
 | `soaRecord` | object | Yes | SOA (Start of Authority) record - defines zone authority and refresh parameters.  The SOA record is required for all authoritative zones and contains timing information for zone transfers and caching. |
 | `ttl` | integer | No | Default TTL (Time To Live) for records in this zone, in seconds.  If not specified, individual records must specify their own TTL. Typical values: 300-86400 (5 minutes to 1 day). |
@@ -258,7 +258,7 @@ CAARecord specifies which certificate authorities are authorized to issue certif
 
 **API Version**: `bindy.firestoned.io/v1alpha1`
 
-Bind9Cluster defines a namespace-scoped logical grouping of BIND9 DNS server instances. Use this for tenant-managed DNS infrastructure isolated to a specific namespace. For platform-managed cluster-wide DNS, use Bind9GlobalCluster instead.
+Bind9Cluster defines a namespace-scoped logical grouping of BIND9 DNS server instances. Use this for tenant-managed DNS infrastructure isolated to a specific namespace. For platform-managed cluster-wide DNS, use ClusterBind9Provider instead.
 
 #### Spec Fields
 
@@ -298,7 +298,7 @@ Bind9Instance represents a BIND9 DNS server deployment in Kubernetes. Each insta
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 | `bindcarConfig` | object | No | Bindcar RNDC API sidecar container configuration.  The API container provides an HTTP interface for managing zones via rndc. If not specified, uses default configuration. |
-| `clusterRef` | string | Yes | Reference to the cluster this instance belongs to.  Can reference either: - A namespace-scoped \`Bind9Cluster\` (must be in the same namespace as this instance) - A cluster-scoped \`Bind9GlobalCluster\` (cluster-wide, accessible from any namespace)  The cluster provides shared configuration and defines the logical grouping. The controller will automatically detect whether this references a namespace-scoped or cluster-scoped cluster resource. |
+| `clusterRef` | string | Yes | Reference to the cluster this instance belongs to.  Can reference either: - A namespace-scoped \`Bind9Cluster\` (must be in the same namespace as this instance) - A cluster-scoped \`ClusterBind9Provider\` (cluster-wide, accessible from any namespace)  The cluster provides shared configuration and defines the logical grouping. The controller will automatically detect whether this references a namespace-scoped or cluster-scoped cluster resource. |
 | `config` | object | No | Instance-specific BIND9 configuration overrides.  Overrides cluster-level configuration for this instance only. |
 | `configMapRefs` | object | No | \`ConfigMap\` references override. Inherits from cluster if not specified. |
 | `image` | object | No | Container image configuration override. Inherits from cluster if not specified. |

--- a/examples/cluster-bind9-provider.yaml
+++ b/examples/cluster-bind9-provider.yaml
@@ -1,8 +1,8 @@
 ---
-# Platform DNS Cluster - Cluster-Scoped (Global)
-# This cluster can be referenced from DNSZones in any namespace
+# Platform DNS Cluster - Cluster-Scoped Provider
+# This cluster provider can be referenced from DNSZones in any namespace
 apiVersion: bindy.firestoned.io/v1alpha1
-kind: Bind9GlobalCluster
+kind: ClusterBind9Provider
 metadata:
   name: production-dns
   labels:
@@ -10,7 +10,7 @@ metadata:
     managed-by: platform-team
 spec:
   # Namespace where Bind9Instance resources will be created (optional)
-  # Global clusters are cluster-scoped, but instances must live in a namespace
+  # Cluster providers are cluster-scoped, but instances must live in a namespace
   # If not specified, defaults to the namespace where the Bindy operator is running
   namespace: dns-system
   version: "9.18"

--- a/examples/dns-zone.yaml
+++ b/examples/dns-zone.yaml
@@ -8,7 +8,7 @@ spec:
   zoneName: example.com
   # Reference to the Bind9Cluster that manages this zone
   # This must match the Bind9Cluster name, NOT the Bind9Instance name
-  globalClusterRef: production-dns
+  clusterProviderRef: production-dns
   nameServerIps:
     ns1.example.com.: 192.168.0.60
   soaRecord:
@@ -30,7 +30,7 @@ spec:
   zoneName: internal.local
   # Reference to the Bind9Cluster that manages this zone
   # This must match the Bind9Cluster name, NOT the Bind9Instance name
-  globalClusterRef: production-dns
+  clusterProviderRef: production-dns
   nameServerIps:
     ns1.internal.local.: 192.168.0.60
   soaRecord:

--- a/examples/multi-tenancy.yaml
+++ b/examples/multi-tenancy.yaml
@@ -7,7 +7,7 @@
 #
 # This example demonstrates both multi-tenancy models supported by Bindy:
 #
-# 1. Platform-Managed DNS: Shared cluster-scoped Bind9GlobalCluster
+# 1. Platform-Managed DNS: Shared cluster-scoped ClusterBind9Provider
 #    - Platform team manages the DNS infrastructure (ClusterRole required)
 #    - Application teams manage their own zones and records (Role required)
 #    - Suitable for production workloads with centralized DNS management
@@ -20,13 +20,13 @@
 # Components:
 # - Namespaces: team-web, team-api
 # - RBAC: Roles and RoleBindings for platform and application teams
-# - Platform DNS: Bind9GlobalCluster (cluster-scoped, deployed separately)
+# - Platform DNS: ClusterBind9Provider (cluster-scoped, deployed separately)
 # - Tenant DNS: Bind9Cluster (namespace-scoped) in team-api namespace
 # - DNS Zones and Records for both models
 #
 # Prerequisites:
 # - Deploy the platform DNS cluster first: kubectl apply -f examples/bind9-cluster.yaml
-#   This creates a Bind9GlobalCluster named 'production-dns' (cluster-scoped resource)
+#   This creates a ClusterBind9Provider named 'production-dns' (cluster-scoped resource)
 #
 # Deployment:
 #   kubectl apply -f examples/multi-tenancy.yaml
@@ -213,12 +213,12 @@ metadata:
 
 ---
 # ============================================================================
-# Platform-Managed DNS: DNSZone for Web Team (uses globalClusterRef)
+# Platform-Managed DNS: DNSZone for Web Team (uses clusterProviderRef)
 # ============================================================================
-# The platform DNS cluster (production-dns) is a Bind9GlobalCluster
+# The platform DNS cluster (production-dns) is a ClusterBind9Provider
 # deployed separately via: kubectl apply -f examples/bind9-cluster.yaml
 #
-# DNSZones reference it using globalClusterRef, which works across namespaces
+# DNSZones reference it using clusterProviderRef, which works across namespaces
 # ============================================================================
 
 apiVersion: bindy.firestoned.io/v1alpha1
@@ -231,7 +231,7 @@ metadata:
     environment: production
 spec:
   zoneName: web.example.com
-  globalClusterRef: production-dns  # References cluster-scoped Bind9GlobalCluster
+  clusterProviderRef: production-dns  # References cluster-scoped ClusterBind9Provider
   nameServerIps:
     ns1.example.com.: 192.168.0.60
   soaRecord:
@@ -457,7 +457,7 @@ metadata:
     environment: production
 spec:
   zoneName: api.example.com
-  globalClusterRef: production-dns  # API team uses platform DNS for production
+  clusterProviderRef: production-dns  # API team uses platform DNS for production
   nameServerIps:
     ns1.example.com.: 192.168.0.60
   soaRecord:

--- a/src/bin/crdgen.rs
+++ b/src/bin/crdgen.rs
@@ -12,7 +12,7 @@
 //! Generated files will be written to deploy/crds/ with proper headers.
 
 use bindy::crd::{
-    AAAARecord, ARecord, Bind9Cluster, Bind9GlobalCluster, Bind9Instance, CAARecord, CNAMERecord,
+    AAAARecord, ARecord, Bind9Cluster, Bind9Instance, CAARecord, CNAMERecord, ClusterBind9Provider,
     DNSZone, MXRecord, NSRecord, SRVRecord, TXTRecord,
 };
 use kube::CustomResourceExt;
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     generate_crd::<CAARecord>("caarecords.crd.yaml", output_dir)?;
     generate_crd::<DNSZone>("dnszones.crd.yaml", output_dir)?;
     generate_crd::<Bind9Cluster>("bind9clusters.crd.yaml", output_dir)?;
-    generate_crd::<Bind9GlobalCluster>("bind9globalclusters.crd.yaml", output_dir)?;
+    generate_crd::<ClusterBind9Provider>("clusterbind9providers.crd.yaml", output_dir)?;
     generate_crd::<Bind9Instance>("bind9instances.crd.yaml", output_dir)?;
 
     println!("✓ Successfully generated CRD YAML files in deploy/crds/");

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -49,8 +49,8 @@ pub const KIND_CAA_RECORD: &str = "CAARecord";
 /// Kind name for `Bind9Cluster` resource
 pub const KIND_BIND9_CLUSTER: &str = "Bind9Cluster";
 
-/// Kind name for `Bind9GlobalCluster` resource
-pub const KIND_BIND9_GLOBALCLUSTER: &str = "Bind9GlobalCluster";
+/// Kind name for `ClusterBind9Provider` resource
+pub const KIND_CLUSTER_BIND9_PROVIDER: &str = "ClusterBind9Provider";
 
 /// Kind name for `Bind9Instance` resource
 pub const KIND_BIND9_INSTANCE: &str = "Bind9Instance";

--- a/src/crd_docs.rs
+++ b/src/crd_docs.rs
@@ -25,7 +25,7 @@
 /// let spec = DNSZoneSpec {
 ///     zone_name: "example.com".to_string(),
 ///     cluster_ref: Some("my-dns-cluster".to_string()),
-///     global_cluster_ref: None,
+///     cluster_provider_ref: None,
 ///     soa_record: soa,
 ///     ttl: Some(3600),
 ///     name_server_ips: None,

--- a/src/crd_tests.rs
+++ b/src/crd_tests.rs
@@ -129,7 +129,7 @@ mod tests {
         let spec = DNSZoneSpec {
             zone_name: "example.com".into(),
             cluster_ref: Some("my-cluster".into()),
-            global_cluster_ref: None,
+            cluster_provider_ref: None,
             soa_record: soa,
             ttl: Some(3600),
             name_server_ips: None,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -52,8 +52,8 @@ pub const MANAGED_BY_BIND9_INSTANCE: &str = "Bind9Instance";
 /// Value for `app.kubernetes.io/managed-by` when resource is managed by `Bind9Cluster` controller
 pub const MANAGED_BY_BIND9_CLUSTER: &str = "Bind9Cluster";
 
-/// Value for `app.kubernetes.io/managed-by` when resource is managed by `Bind9GlobalCluster` controller
-pub const MANAGED_BY_BIND9_GLOBAL_CLUSTER: &str = "Bind9GlobalCluster";
+/// Value for `app.kubernetes.io/managed-by` when resource is managed by `ClusterBind9Provider` controller
+pub const MANAGED_BY_CLUSTER_BIND9_PROVIDER: &str = "ClusterBind9Provider";
 
 // ============================================================================
 // Bindy-Specific Labels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! let zone_spec = DNSZoneSpec {
 //!     zone_name: "example.com".to_string(),
 //!     cluster_ref: Some("my-dns-cluster".to_string()),
-//!     global_cluster_ref: None,
+//!     cluster_provider_ref: None,
 //!     soa_record: soa,
 //!     ttl: Some(3600),
 //!     name_server_ips: None,

--- a/src/reconcilers/bind9cluster.rs
+++ b/src/reconcilers/bind9cluster.rs
@@ -768,7 +768,7 @@ async fn ensure_managed_instance_resources(
 
 /// Create a managed `Bind9Instance` resource
 ///
-/// This function is public to allow reuse by `Bind9GlobalCluster` reconciler.
+/// This function is public to allow reuse by `ClusterBind9Provider` reconciler.
 ///
 /// # Arguments
 ///
@@ -1019,7 +1019,7 @@ async fn create_or_update_cluster_configmap(client: &Client, cluster: &Bind9Clus
 
 /// Delete a single managed `Bind9Instance` resource
 ///
-/// This function is public to allow reuse by `Bind9GlobalCluster` reconciler.
+/// This function is public to allow reuse by `ClusterBind9Provider` reconciler.
 ///
 /// # Arguments
 ///

--- a/src/reconcilers/clusterbind9provider_tests.rs
+++ b/src/reconcilers/clusterbind9provider_tests.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 Erick Bourgeois, firestoned
 // SPDX-License-Identifier: MIT
 
-//! Unit tests for `bind9globalcluster.rs`
+//! Unit tests for `clusterbind9provider.rs`
 
 #[cfg(test)]
 mod tests {
-    use super::super::bind9globalcluster::calculate_cluster_status;
+    use super::super::clusterbind9provider::calculate_cluster_status;
     use crate::crd::{
         Bind9Instance, Bind9InstanceSpec, Bind9InstanceStatus, Condition, ServerRole,
     };

--- a/src/reconcilers/finalizers.rs
+++ b/src/reconcilers/finalizers.rs
@@ -338,9 +338,9 @@ where
 ///
 /// ```rust,no_run
 /// # use bindy::reconcilers::finalizers::ensure_cluster_finalizer;
-/// # use bindy::crd::Bind9GlobalCluster;
+/// # use bindy::crd::ClusterBind9Provider;
 /// # use kube::Client;
-/// # async fn example(client: Client, cluster: Bind9GlobalCluster) {
+/// # async fn example(client: Client, cluster: ClusterBind9Provider) {
 /// const FINALIZER: &str = "bind9globalcluster.dns.firestoned.io/finalizer";
 /// ensure_cluster_finalizer(&client, &cluster, FINALIZER).await.unwrap();
 /// # }
@@ -496,13 +496,13 @@ where
 ///
 /// ```text
 /// use bindy::reconcilers::finalizers::{handle_cluster_deletion, FinalizerCleanup};
-/// use bindy::crd::Bind9GlobalCluster;
+/// use bindy::crd::ClusterBind9Provider;
 /// use kube::Client;
 /// use anyhow::Result;
 ///
 /// const FINALIZER: &str = "bind9globalcluster.dns.firestoned.io/finalizer";
 ///
-/// async fn reconcile(client: Client, cluster: Bind9GlobalCluster) -> Result<()> {
+/// async fn reconcile(client: Client, cluster: ClusterBind9Provider) -> Result<()> {
 ///     if cluster.metadata.deletion_timestamp.is_some() {
 ///         return handle_cluster_deletion(&client, &cluster, FINALIZER).await;
 ///     }

--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -22,8 +22,8 @@
 //!
 //! - [`reconcile_bind9cluster`] - Manages namespace-scoped BIND9 cluster status
 //! - [`delete_bind9cluster`] - Cleans up namespace-scoped BIND9 cluster resources
-//! - [`reconcile_bind9globalcluster`] - Manages cluster-scoped BIND9 global cluster status
-//! - [`delete_bind9globalcluster`] - Cleans up cluster-scoped BIND9 global cluster resources
+//! - [`reconcile_clusterbind9provider`] - Manages cluster-scoped BIND9 provider status
+//! - [`delete_clusterbind9provider`] - Cleans up cluster-scoped BIND9 provider resources
 //! - [`reconcile_bind9instance`] - Creates/updates BIND9 server deployments
 //! - [`delete_bind9instance`] - Cleans up BIND9 server resources
 //!
@@ -61,8 +61,8 @@
 //! ```
 
 pub mod bind9cluster;
-pub mod bind9globalcluster;
 pub mod bind9instance;
+pub mod clusterbind9provider;
 pub mod dnszone;
 pub mod finalizers;
 pub mod records;
@@ -72,17 +72,17 @@ pub mod status;
 #[cfg(test)]
 mod bind9cluster_tests;
 #[cfg(test)]
-mod bind9globalcluster_tests;
-#[cfg(test)]
 mod bind9instance_tests;
+#[cfg(test)]
+mod clusterbind9provider_tests;
 #[cfg(test)]
 mod dnszone_tests;
 #[cfg(test)]
 mod records_tests;
 
 pub use bind9cluster::{delete_bind9cluster, reconcile_bind9cluster};
-pub use bind9globalcluster::{delete_bind9globalcluster, reconcile_bind9globalcluster};
 pub use bind9instance::{delete_bind9instance, reconcile_bind9instance};
+pub use clusterbind9provider::{delete_clusterbind9provider, reconcile_clusterbind9provider};
 pub use dnszone::{delete_dnszone, reconcile_dnszone};
 pub use records::{
     reconcile_a_record, reconcile_aaaa_record, reconcile_caa_record, reconcile_cname_record,

--- a/src/status_reasons.rs
+++ b/src/status_reasons.rs
@@ -11,7 +11,7 @@
 //!
 //! Bindy uses a hierarchical status tracking system where each resource tracks its children:
 //!
-//! - **`Bind9GlobalCluster`** → tracks `Bind9Cluster` resources
+//! - **`ClusterBind9Provider`** → tracks `Bind9Cluster` resources
 //! - **`Bind9Cluster`** → tracks `Bind9Instance` resources
 //! - **`Bind9Instance`** → tracks `Pod` replicas
 //!
@@ -220,7 +220,7 @@ pub const REASON_INSTANCES_SCALING: &str = "InstancesScaling";
 pub const REASON_INSTANCES_PENDING: &str = "InstancesPending";
 
 // ============================================================================
-// Bind9GlobalCluster Specific Reasons
+// ClusterBind9Provider Specific Reasons
 // ============================================================================
 
 /// All namespace-scoped `Bind9Cluster` resources are ready.

--- a/src/status_reasons_tests.rs
+++ b/src/status_reasons_tests.rs
@@ -134,7 +134,7 @@ mod tests {
     }
 
     // ============================================================================
-    // Test Bind9GlobalCluster Specific Reason Constants
+    // Test ClusterBind9Provider Specific Reason Constants
     // ============================================================================
 
     #[test]


### PR DESCRIPTION
1. CRD Definition - Updated [src/crd.rs](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/src/crd.rs)

- Renamed kind: Bind9GlobalCluster → ClusterBind9Provider
- Renamed spec: Bind9GlobalClusterSpec → ClusterBind9ProviderSpec
- Updated shortnames: b9gc, b9gcs → cb9p, cb9ps
- Updated DNSZone field: global_cluster_ref → cluster_provider_ref

1. Constants & Labels

[src/constants.rs](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/src/constants.rs:53): KIND_CLUSTER_BIND9_PROVIDER
[src/labels.rs](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/src/labels.rs:56): MANAGED_BY_CLUSTER_BIND9_PROVIDER

1. Reconcilers

- Renamed file: bind9globalcluster.rs → clusterbind9provider.rs
- Updated all function names and references
- Updated [src/main.rs](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/src/main.rs) controller registration
- Updated all other reconcilers (dnszone, bind9instance, bind9cluster, records, finalizers)

1. Test Files

- Renamed: bind9globalcluster_tests.rs → clusterbind9provider_tests.rs
- Updated all test imports and references
- **All 422 tests passing** ✅

1. CRD YAML Files

- Generated new: deploy/crds/clusterbind9providers.crd.yaml
- Deleted old: deploy/crds/bind9globalclusters.crd.yaml
- Regenerated: deploy/crds/dnszones.crd.yaml
- 

1. Examples

- Updated [examples/bind9-cluster.yaml](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/examples/bind9-cluster.yaml)
- Updated [examples/dns-zone.yaml](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/examples/dns-zone.yaml)
- Updated [examples/multi-tenancy.yaml](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/examples/multi-tenancy.yaml)

1. Documentation

- Renamed: bind9globalcluster.md → clusterbind9provider.md
- Updated 11 documentation files in docs/src/
- Updated [docs/src/SUMMARY.md](vscode-webview://17jnfmebll1dcv80pvi8a4r0isqgqch5cprupqd51i02eolrerik/docs/src/SUMMARY.md)

1. Code Quality

- ✅ cargo fmt - All code formatted
- ✅ cargo clippy - No warnings
- ✅ cargo test - All 422 tests passing

1. CHANGELOG.md - Comprehensive entry with:

- Detailed list of all changes
- Rationale for the rename
- Migration steps for users
 
### Key Changes

**New naming provides better clarity:**

- "Cluster" prefix explicitly indicates cluster scope
- "Provider" better describes the DNS infrastructure provisioning role
- Aligns with Kubernetes conventions (ClusterRole, ClusterRoleBinding)

### Migration Path

1. Users can migrate by:
2. Backing up existing resources
3. Updating CRDs
4. Changing kind: and field names in their YAML files
5. Reapplying resources