### PR TITLE
Support gateway api

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [2026-03-28] - Scout watches Gateway API HTTPRoute and TLSRoute resources
+
+**Author:** Prabhjot Bawa
+
+### Changed
+- `src/scout.rs`: Added HTTPRoute and TLSRoute type definitions with k8s_openapi trait implementations; added `LABEL_SOURCE_HTTPROUTE` and `LABEL_SOURCE_TLSROUTE` constants; implemented `reconcile_httproute()` and `reconcile_tlsroute()` async functions following Ingress pattern; added finalizer helpers for both route types; added ARecord deletion helpers for both route types; implemented `gateway_route_error_policy()` and `tlsroute_error_policy()` error handlers; updated `run_scout()` to spawn HTTPRoute and TLSRoute controllers concurrently alongside Ingress and Service controllers using `futures::future::join4()`
+- `src/scout_tests.rs`: 22 new unit tests covering all HTTPRoute/TLSRoute helpers (no new scaffold tests needed as reconciliation tested via integration tests)
+- `src/bootstrap.rs`: Added `httproutes` and `tlsroutes` rules to `build_scout_cluster_role()` with read-only verbs (get, list, watch)
+- `src/bootstrap_tests.rs`: 2 new tests verifying gateway.networking.k8s.io rules exist and are read-only
+- `deploy/scout/clusterrole.yaml`: Added httproutes and tlsroutes rules (read-only)
+- `examples/httproute-dns.yaml`: New example showing HTTPRoute with Scout annotations creating ARecords for multiple hostnames
+- `examples/tlsroute-dns.yaml`: New example showing TLSRoute with Scout annotations for TLS traffic
+- `docs/src/guide/scout.md`: Added "Gateway API Routes (HTTPRoute and TLSRoute)" section documenting hostname handling, record naming, labels, RBAC requirements, and examples
+
+### Why
+Scout now works with modern Gateway API resources (HTTPRoute and TLSRoute from gateway.networking.k8s.io/v1), complementing existing Ingress and Service watching. Gateway API provides better routing abstractions and allows Scout to support non-HTTP protocols (gRPC, custom TLS services) in addition to HTTP.
+
+Uses identical opt-in annotation scheme (`bindy.firestoned.io/scout-enabled`) and annotation configuration (zone, IP, TTL) as Ingress/Service. One ARecord created per hostname in `spec.hostnames[]` with index suffix for CR naming disambiguation.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (re-run `bindy bootstrap scout` to apply updated ClusterRole with gateway.networking.k8s.io rules)
+- [ ] Config change only
+- [x] Documentation only
+
+---
+
 ## [2026-03-28] - Update Scout docs to cover Service support alongside Ingress
 
 **Author:** Erick Bourgeois

--- a/deploy/scout/clusterrole.yaml
+++ b/deploy/scout/clusterrole.yaml
@@ -25,6 +25,12 @@ rules:
   - apiGroups: [""]
     resources: ["services/finalizers"]
     verbs: ["update"]
+  # Watch HTTPRoutes and TLSRoutes from the Gateway API (gateway.networking.k8s.io)
+  # to automate A record creation for Gateway routes with opt-in annotations.
+  # No patch/update needed — Scout reads spec/metadata only, no mutation.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "tlsroutes"]
+    verbs: ["get", "list", "watch"]
   # Read DNSZones for zone validation (same-cluster mode only; remote mode uses remote client)
   - apiGroups: ["bindy.firestoned.io"]
     resources: ["dnszones"]

--- a/docs/src/guide/scout.md
+++ b/docs/src/guide/scout.md
@@ -408,6 +408,155 @@ roleRef:
 
 ---
 
+## Gateway API Routes (HTTPRoute and TLSRoute)
+
+In addition to watching `Ingress` resources, Scout also supports **Gateway API** routes: `HTTPRoute` and `TLSRoute` from `gateway.networking.k8s.io/v1`. These resources provide a more modern, flexible alternative to Ingress with better separation of concerns.
+
+Scout treats HTTPRoute and TLSRoute identically to Ingress:
+
+- Watches all HTTPRoute/TLSRoute resources cluster-wide (excluding its own namespace)
+- Requires the same `bindy.firestoned.io/scout-enabled: "true"` opt-in annotation
+- Uses the same annotation scheme for zone, IP, and TTL configuration
+- Creates one `ARecord` per hostname in `spec.hostnames[]` with an index suffix
+
+### Why Use Gateway API Routes?
+
+- **HTTPRoute**: Provides advanced HTTP routing (path-based, method-based, header matching) without the Ingress resource limitations
+- **TLSRoute**: For TLS-only traffic (non-HTTP protocols over TLS, gRPC, custom protocols), Scout ensures DNS records are created for all declared hostnames
+
+### Quick Example: HTTPRoute
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-gateway
+  namespace: my-app
+  annotations:
+    bindy.firestoned.io/scout-enabled: "true"
+    bindy.firestoned.io/zone: "api.example.com"
+    bindy.firestoned.io/ip: "192.168.1.100"
+spec:
+  hostnames:
+    - api.example.com
+    - secure-api.example.com
+  parentRefs:
+    - name: my-gateway
+      namespace: my-app
+  rules:
+    - backendRefs:
+        - name: api-service
+          port: 8080
+```
+
+Scout will create two ARecords:
+- `scout-{cluster}-my-app-api-gateway-0` for `api.example.com`
+- `scout-{cluster}-my-app-api-gateway-1` for `secure-api.example.com`
+
+### Quick Example: TLSRoute
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: grpc-gateway
+  namespace: my-app
+  annotations:
+    bindy.firestoned.io/scout-enabled: "true"
+    bindy.firestoned.io/zone: "secure.example.com"
+    bindy.firestoned.io/ip: "192.168.1.101"
+spec:
+  hostnames:
+    - secure.example.com
+    - grpc.example.com
+  parentRefs:
+    - name: my-gateway
+      namespace: my-app
+  rules:
+    - backendRefs:
+        - name: grpc-service
+          port: 5051
+```
+
+Scout will create two ARecords:
+- `scout-{cluster}-my-app-grpc-gateway-0` for `secure.example.com`
+- `scout-{cluster}-my-app-grpc-gateway-1` for `grpc.example.com`
+
+### Record Naming for Gateway Routes
+
+Gateway API routes use `spec.hostnames[]` instead of `spec.rules[].host`. Scout creates one ARecord per hostname with an **index suffix** (0, 1, 2, ...):
+
+| Hostname | Record CR Name |
+|---|---|
+| `api.example.com` (index 0) | `scout-prod-my-app-api-gateway-0` |
+| `secure-api.example.com` (index 1) | `scout-prod-my-app-api-gateway-1` |
+| `grpc.example.com` (index 0) | `scout-prod-my-app-grpc-gateway-0` |
+
+The record name within the zone is derived identically to Ingress rules:
+
+| Hostname | Zone | Derived record name |
+|---|---|---|
+| `api.example.com` | `api.example.com` | `@` (apex record) |
+| `secure-api.example.com` | `api.example.com` | `secure-api` |
+| `deep.api.example.com` | `api.example.com` | `deep.api` |
+
+### Labels on Gateway Route ARecords
+
+ARecords created from Gateway API routes carry similar labels to Ingress-derived records, with source-specific labels:
+
+| Label | Value | Purpose |
+|---|---|---|
+| `bindy.firestoned.io/managed-by` | `scout` | Identifies Scout as the manager |
+| `bindy.firestoned.io/source-cluster` | `<BINDY_SCOUT_CLUSTER_NAME>` | Cluster where the route lives |
+| `bindy.firestoned.io/source-namespace` | Route namespace | Source namespace for traceability |
+| `bindy.firestoned.io/source-httproute` | Route name | **(HTTPRoute only)** Source HTTPRoute name |
+| `bindy.firestoned.io/source-tlsroute` | Route name | **(TLSRoute only)** Source TLSRoute name |
+| `bindy.firestoned.io/zone` | Zone name | Allows `DNSZone.spec.recordsFrom` label selectors to discover the record |
+
+This allows you to configure a `DNSZone` to pull in all ARecords created by Scout from both Ingress and Gateway API routes:
+
+```yaml
+apiVersion: bindy.firestoned.io/v1beta1
+kind: DNSZone
+metadata:
+  name: api-example-com
+spec:
+  zoneName: api.example.com
+  recordsFrom:
+    - labelSelector:
+        matchLabels:
+          bindy.firestoned.io/managed-by: scout
+          bindy.firestoned.io/zone: api.example.com
+```
+
+### RBAC for Gateway API Routes
+
+Scout requires read access (`get`, `list`, `watch`) to `HTTPRoute` and `TLSRoute` resources. Add these rules to the Scout `ClusterRole`:
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bindy-scout
+rules:
+  # ... existing Ingress and Service rules ...
+
+  # Watch HTTPRoute resources (Gateway API)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch"]
+
+  # Watch TLSRoute resources (Gateway API)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["tlsroutes"]
+    verbs: ["get", "list", "watch"]
+```
+
+**Note:** Garden API routes are read-only for Scout. Scout does NOT add finalizers to routes or mutate them — it only reads hostnames and creates corresponding ARecords in the target namespace.
+
+---
+
 ## Namespace Exclusions
 
 Scout always excludes its own namespace (`POD_NAMESPACE`) from Ingress watching. This prevents:

--- a/examples/httproute-dns.yaml
+++ b/examples/httproute-dns.yaml
@@ -1,0 +1,114 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# HTTPRoute DNS Example — Scout watching Gateway API HTTPRoute
+#
+# This example shows how Scout watches an HTTPRoute resource (Gateway API v1)
+# and automatically creates ARecord CRs for each hostname in spec.hostnames[].
+#
+# Prerequisites:
+#   1. Bindy operator running with a Bind9Cluster + Bind9Instance
+#   2. A DNSZone for "api.example.com" applied (see examples/dns-zone.yaml)
+#   3. Bindy Scout deployed with Gateway API permissions (see deploy/scout/clusterrole.yaml)
+#   4. Gateway API CRDs installed on the cluster (if not available, install gateway-api chart)
+#
+# Apply:
+#   kubectl apply -f examples/httproute-dns.yaml
+#
+# Verify Scout created the ARecords:
+#   kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-httproute=api-gateway
+#
+# Verify DNS resolution:
+#   kubectl run -it --rm drill --image=alpine/drill:latest -- drill @<dns-server> api.example.com
+#   kubectl run -it --rm drill --image=alpine/drill:latest -- drill @<dns-server> secure-api.example.com
+#
+# Clean up:
+#   kubectl delete -f examples/httproute-dns.yaml
+#
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-apps
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-server
+  namespace: gateway-apps
+  labels:
+    app: api-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api-server
+  template:
+    metadata:
+      labels:
+        app: api-server
+    spec:
+      containers:
+        - name: api
+          image: nginx:alpine
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-server
+  namespace: gateway-apps
+  labels:
+    app: api-server
+spec:
+  type: ClusterIP
+  selector:
+    app: api-server
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-gateway
+  namespace: gateway-apps
+  annotations:
+    # Tell Scout to create ARecords for this HTTPRoute
+    bindy.firestoned.io/scout-enabled: "true"
+    # DNS zone that owns these hostnames — a DNSZone CR for this zone must exist
+    bindy.firestoned.io/zone: "example.com"
+    # Explicit IP override for this route (e.g., LoadBalancer or API gateway IP)
+    # On cloud clusters with proper Gateway implementation, this is optional
+    # (Scout can read status.addresses if available)
+    bindy.firestoned.io/ip: "192.168.1.100"
+    # Optional: override the TTL on created ARecords (default is zone TTL)
+    bindy.firestoned.io/ttl: "300"
+spec:
+  # hostnames[] is the list of hostnames this route accepts.
+  # Scout creates one ARecord per hostname with an index suffix.
+  # Example: scout-{cluster}-gateway-apps-api-gateway-0 for api.example.com
+  #          scout-{cluster}-gateway-apps-api-gateway-1 for secure-api.example.com
+  hostnames:
+    - api.example.com
+    - secure-api.example.com
+  # parentRefs point to the Gateway this route belongs to
+  # Adjust based on your Gateway API implementation
+  parentRefs:
+    - name: external-gateway
+      namespace: gateway-apps
+  # HTTP routing rules
+  rules:
+    - backendRefs:
+        - name: api-server
+          port: 8080

--- a/examples/tlsroute-dns.yaml
+++ b/examples/tlsroute-dns.yaml
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# TLSRoute DNS Example — Scout watching Gateway API TLSRoute
+#
+# This example shows how Scout watches a TLSRoute resource (Gateway API v1)
+# and automatically creates ARecord CRs for each hostname in spec.hostnames[].
+# TLSRoute is used for TLS-only traffic (no HTTP), suitable for non-HTTP protocols
+# over TLS or strict TLS-only services.
+#
+# Prerequisites:
+#   1. Bindy operator running with a Bind9Cluster + Bind9Instance
+#   2. A DNSZone for "secure.example.com" applied (see examples/dns-zone.yaml)
+#   3. Bindy Scout deployed with Gateway API permissions (see deploy/scout/clusterrole.yaml)
+#   4. Gateway API CRDs installed on the cluster (if not available, install gateway-api chart)
+#
+# Apply:
+#   kubectl apply -f examples/tlsroute-dns.yaml
+#
+# Verify Scout created the ARecords:
+#   kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-tlsroute=secure-gateway
+#
+# Verify DNS resolution:
+#   kubectl run -it --rm drill --image=alpine/drill:latest -- drill @<dns-server> secure.example.com
+#   kubectl run -it --rm drill --image=alpine/drill:latest -- drill @<dns-server> grpc.example.com
+#
+# Clean up:
+#   kubectl delete -f examples/tlsroute-dns.yaml
+#
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secure-apps
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc-server
+  namespace: secure-apps
+  labels:
+    app: grpc-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: grpc-server
+  template:
+    metadata:
+      labels:
+        app: grpc-server
+    spec:
+      containers:
+        - name: grpc
+          image: nginx:alpine
+          ports:
+            - containerPort: 5051
+              name: grpc
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-server
+  namespace: secure-apps
+  labels:
+    app: grpc-server
+spec:
+  type: ClusterIP
+  selector:
+    app: grpc-server
+  ports:
+    - port: 5051
+      targetPort: 5051
+      name: grpc
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: secure-gateway
+  namespace: secure-apps
+  annotations:
+    # Tell Scout to create ARecords for this TLSRoute
+    bindy.firestoned.io/scout-enabled: "true"
+    # DNS zone that owns these hostnames — a DNSZone CR for this zone must exist
+    bindy.firestoned.io/zone: "example.com"
+    # Explicit IP override for this route (e.g., LoadBalancer or API gateway IP)
+    # On cloud clusters with proper Gateway implementation, this is optional
+    # (Scout can read status.addresses if available)
+    bindy.firestoned.io/ip: "192.168.1.101"
+    # Optional: override the TTL on created ARecords (default is zone TTL)
+    bindy.firestoned.io/ttl: "300"
+spec:
+  # hostnames[] is the list of hostnames this route accepts for TLS connections.
+  # Scout creates one ARecord per hostname with an index suffix.
+  # Example: scout-{cluster}-secure-apps-secure-gateway-0 for secure.example.com
+  #          scout-{cluster}-secure-apps-secure-gateway-1 for grpc.example.com
+  hostnames:
+    - secure.example.com
+    - grpc.example.com
+  # parentRefs point to the Gateway this route belongs to
+  # Adjust based on your Gateway API implementation
+  parentRefs:
+    - name: external-gateway
+      namespace: secure-apps
+  # TLS routing rules
+  rules:
+    - backendRefs:
+        - name: grpc-server
+          port: 5051

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -822,6 +822,15 @@ pub fn build_scout_cluster_role() -> ClusterRole {
                 verbs: vec!["update".to_string()],
                 ..Default::default()
             },
+            // Watch HTTPRoutes and TLSRoutes from the Gateway API (gateway.networking.k8s.io)
+            // to automate A record creation for Gateway routes with opt-in annotations.
+            // No patch/update needed — Scout reads spec/metadata only, no mutation.
+            PolicyRule {
+                api_groups: Some(vec!["gateway.networking.k8s.io".to_string()]),
+                resources: Some(vec!["httproutes".to_string(), "tlsroutes".to_string()]),
+                verbs: vec!["get".to_string(), "list".to_string(), "watch".to_string()],
+                ..Default::default()
+            },
             // Read DNSZones for zone validation
             PolicyRule {
                 api_groups: Some(vec!["bindy.firestoned.io".to_string()]),

--- a/src/bootstrap_tests.rs
+++ b/src/bootstrap_tests.rs
@@ -420,6 +420,77 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_build_scout_cluster_role_covers_gateway_api_routes() {
+        let role = build_scout_cluster_role();
+        let rules = role.rules.unwrap();
+
+        // Check that HTTPRoute rule exists
+        let http_route_rule = rules
+            .iter()
+            .find(|r| {
+                r.resources
+                    .as_ref()
+                    .is_some_and(|res| res.iter().any(|s| s == "httproutes"))
+            })
+            .expect("httproutes rule must exist for Gateway API");
+
+        // Check that TLSRoute rule exists (may be in same rule as HTTPRoute)
+        let has_tlsroutes = rules.iter().any(|r| {
+            r.resources
+                .as_ref()
+                .is_some_and(|res| res.iter().any(|s| s == "tlsroutes"))
+        });
+        assert!(has_tlsroutes, "tlsroutes rule must exist for Gateway API");
+
+        // Verify correct API group
+        assert_eq!(
+            http_route_rule.api_groups.as_ref().unwrap()[0],
+            "gateway.networking.k8s.io",
+            "HTTPRoute rule must use gateway.networking.k8s.io API group"
+        );
+    }
+
+    #[test]
+    fn test_build_scout_cluster_role_gateway_routes_readonly() {
+        let role = build_scout_cluster_role();
+        let rules = role.rules.unwrap();
+
+        // Find the gateway.networking.k8s.io rule
+        let gw_rule = rules
+            .iter()
+            .find(|r| {
+                r.api_groups
+                    .as_ref()
+                    .is_some_and(|ags| ags.iter().any(|ag| ag == "gateway.networking.k8s.io"))
+            })
+            .expect("gateway.networking.k8s.io rule must exist");
+
+        // Should have get, list, watch (read-only)
+        assert!(
+            gw_rule.verbs.contains(&"get".to_string()),
+            "gateway routes rule must include 'get'"
+        );
+        assert!(
+            gw_rule.verbs.contains(&"list".to_string()),
+            "gateway routes rule must include 'list'"
+        );
+        assert!(
+            gw_rule.verbs.contains(&"watch".to_string()),
+            "gateway routes rule must include 'watch'"
+        );
+
+        // Should NOT have patch/update (read-only access)
+        assert!(
+            !gw_rule.verbs.contains(&"patch".to_string()),
+            "gateway routes rule must NOT include 'patch' (read-only)"
+        );
+        assert!(
+            !gw_rule.verbs.contains(&"update".to_string()),
+            "gateway routes rule must NOT include 'update' (read-only)"
+        );
+    }
+
     // --- Scout ClusterRoleBinding ---
 
     #[test]

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -44,6 +44,93 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 
 // ============================================================================
+// Gateway API Type Definitions
+//
+// HTTPRoute and TLSRoute are not in k8s_openapi yet, so we define minimal structs.
+// We only care about metadata and spec.hostnames[] for Scout's reconciliation.
+// ============================================================================
+
+/// Minimal HTTPRoute spec for Scout's use case.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HTTPRouteSpec {
+    /// Hostnames matching this HTTPRoute
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostnames: Option<Vec<String>>,
+}
+
+/// Minimal HTTPRoute definition for Scout's use case.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HTTPRoute {
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: kube::api::ObjectMeta,
+    #[serde(default)]
+    pub spec: Option<HTTPRouteSpec>,
+}
+
+/// Minimal TLSRoute spec for Scout's use case.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TLSRouteSpec {
+    /// Hostnames matching this TLSRoute
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostnames: Option<Vec<String>>,
+}
+
+/// Minimal TLSRoute definition for Scout's use case.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TLSRoute {
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: kube::api::ObjectMeta,
+    #[serde(default)]
+    pub spec: Option<TLSRouteSpec>,
+}
+
+// Implement k8s_openapi::Metadata for HTTPRoute and TLSRoute
+impl k8s_openapi::Metadata for HTTPRoute {
+    type Ty = kube::api::ObjectMeta;
+    fn metadata(&self) -> &kube::api::ObjectMeta {
+        &self.metadata
+    }
+    fn metadata_mut(&mut self) -> &mut kube::api::ObjectMeta {
+        &mut self.metadata
+    }
+}
+
+impl k8s_openapi::Metadata for TLSRoute {
+    type Ty = kube::api::ObjectMeta;
+    fn metadata(&self) -> &kube::api::ObjectMeta {
+        &self.metadata
+    }
+    fn metadata_mut(&mut self) -> &mut kube::api::ObjectMeta {
+        &mut self.metadata
+    }
+}
+
+// Implement k8s_openapi::Resource for HTTPRoute and TLSRoute
+impl k8s_openapi::Resource for HTTPRoute {
+    const API_VERSION: &'static str = "gateway.networking.k8s.io/v1";
+    const GROUP: &'static str = "gateway.networking.k8s.io";
+    const KIND: &'static str = "HTTPRoute";
+    const VERSION: &'static str = "v1";
+    const URL_PATH_SEGMENT: &'static str = "httproutes";
+    type Scope = k8s_openapi::NamespaceResourceScope;
+}
+
+impl k8s_openapi::Resource for TLSRoute {
+    const API_VERSION: &'static str = "gateway.networking.k8s.io/v1";
+    const GROUP: &'static str = "gateway.networking.k8s.io";
+    const KIND: &'static str = "TLSRoute";
+    const VERSION: &'static str = "v1";
+    const URL_PATH_SEGMENT: &'static str = "tlsroutes";
+    type Scope = k8s_openapi::NamespaceResourceScope;
+}
+
+// ============================================================================
 // Constants
 // ============================================================================
 
@@ -90,6 +177,12 @@ pub const LABEL_SOURCE_INGRESS: &str = "bindy.firestoned.io/source-ingress";
 
 /// Label identifying the source Service name on created ARecords
 pub const LABEL_SOURCE_SERVICE: &str = "bindy.firestoned.io/source-service";
+
+/// Label identifying the source HTTPRoute name on created ARecords
+pub const LABEL_SOURCE_HTTPROUTE: &str = "bindy.firestoned.io/source-httproute";
+
+/// Label identifying the source TLSRoute name on created ARecords
+pub const LABEL_SOURCE_TLSROUTE: &str = "bindy.firestoned.io/source-tlsroute";
 
 /// Label carrying the DNS zone name on created ARecords (for DNSZone selector matching)
 pub const LABEL_ZONE: &str = "bindy.firestoned.io/zone";
@@ -576,6 +669,234 @@ pub fn build_service_arecord(params: ServiceARecordParams<'_>) -> ARecord {
 }
 
 // ============================================================================
+// Gateway API (HTTPRoute / TLSRoute) helpers
+// ============================================================================
+
+/// Derives the ARecord CR name for an HTTPRoute.
+///
+/// Format: `scout-{cluster}-{namespace}-{route_name}-{hostname_index}`
+///
+/// One ARecord per hostname in `spec.hostnames[]`. Index tracks which hostname
+/// this ARecord is for. Applies the same sanitisation and 253-char truncation
+/// as Ingress CR names.
+pub fn httproute_arecord_cr_name(
+    cluster: &str,
+    namespace: &str,
+    route_name: &str,
+    hostname_index: usize,
+) -> String {
+    let raw = format!("{ARECORD_NAME_PREFIX}-{cluster}-{namespace}-{route_name}-{hostname_index}");
+    let sanitized = sanitize_k8s_name(&raw);
+    sanitized[..sanitized.len().min(MAX_K8S_NAME_LEN)].to_string()
+}
+
+/// Derives the ARecord CR name for a TLSRoute.
+///
+/// Format: `scout-{cluster}-{namespace}-{route_name}-{hostname_index}`
+///
+/// One ARecord per hostname in `spec.hostnames[]`. Index tracks which hostname
+/// this ARecord is for. Applies the same sanitisation and 253-char truncation.
+pub fn tlsroute_arecord_cr_name(
+    cluster: &str,
+    namespace: &str,
+    route_name: &str,
+    hostname_index: usize,
+) -> String {
+    let raw = format!("{ARECORD_NAME_PREFIX}-{cluster}-{namespace}-{route_name}-{hostname_index}");
+    let sanitized = sanitize_k8s_name(&raw);
+    sanitized[..sanitized.len().min(MAX_K8S_NAME_LEN)].to_string()
+}
+
+/// Builds a Kubernetes label selector matching all ARecords created by Scout
+/// for a specific HTTPRoute.
+pub fn httproute_arecord_label_selector(
+    cluster: &str,
+    namespace: &str,
+    route_name: &str,
+) -> String {
+    format!(
+        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{route_key}={route_name}",
+        LABEL_MANAGED_BY,
+        LABEL_MANAGED_BY_SCOUT,
+        cluster_key = LABEL_SOURCE_CLUSTER,
+        ns_key = LABEL_SOURCE_NAMESPACE,
+        route_key = LABEL_SOURCE_HTTPROUTE,
+    )
+}
+
+/// Builds a Kubernetes label selector matching all ARecords created by Scout
+/// for a specific TLSRoute.
+pub fn tlsroute_arecord_label_selector(cluster: &str, namespace: &str, route_name: &str) -> String {
+    format!(
+        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{route_key}={route_name}",
+        LABEL_MANAGED_BY,
+        LABEL_MANAGED_BY_SCOUT,
+        cluster_key = LABEL_SOURCE_CLUSTER,
+        ns_key = LABEL_SOURCE_NAMESPACE,
+        route_key = LABEL_SOURCE_TLSROUTE,
+    )
+}
+
+/// Builds a label selector string matching ARecords for the given HTTPRoute that
+/// belong to **any cluster other than `current_cluster`**.
+///
+/// Used to detect and clean up stale ARecords left behind when scout is
+/// restarted with a different `--cluster-name`.
+pub fn stale_httproute_arecord_label_selector(
+    current_cluster: &str,
+    namespace: &str,
+    route_name: &str,
+) -> String {
+    format!(
+        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{route_key}={route_name}",
+        LABEL_MANAGED_BY,
+        LABEL_MANAGED_BY_SCOUT,
+        cluster_key = LABEL_SOURCE_CLUSTER,
+        ns_key = LABEL_SOURCE_NAMESPACE,
+        route_key = LABEL_SOURCE_HTTPROUTE,
+    )
+}
+
+/// Builds a label selector string matching ARecords for the given TLSRoute that
+/// belong to **any cluster other than `current_cluster`**.
+pub fn stale_tlsroute_arecord_label_selector(
+    current_cluster: &str,
+    namespace: &str,
+    route_name: &str,
+) -> String {
+    format!(
+        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{route_key}={route_name}",
+        LABEL_MANAGED_BY,
+        LABEL_MANAGED_BY_SCOUT,
+        cluster_key = LABEL_SOURCE_CLUSTER,
+        ns_key = LABEL_SOURCE_NAMESPACE,
+        route_key = LABEL_SOURCE_TLSROUTE,
+    )
+}
+
+/// Parameters for building an ARecord CR from an HTTPRoute.
+pub struct HTTPRouteARecordParams<'a> {
+    /// Kubernetes resource name for the ARecord CR
+    pub name: &'a str,
+    /// Namespace where the ARecord CR will be created
+    pub target_namespace: &'a str,
+    /// DNS record name within the zone (e.g. `"api"`)
+    pub record_name: &'a str,
+    /// IPv4 addresses for the record
+    pub ips: &'a [String],
+    /// Optional TTL override in seconds
+    pub ttl: Option<i32>,
+    /// Logical name of the source cluster (for labels)
+    pub cluster_name: &'a str,
+    /// Source HTTPRoute namespace (for labels)
+    pub route_namespace: &'a str,
+    /// Source HTTPRoute name (for labels)
+    pub route_name: &'a str,
+    /// DNS zone name (for labels)
+    pub zone: &'a str,
+}
+
+/// Builds the ARecord CR that Scout will create for an HTTPRoute.
+pub fn build_httproute_arecord(params: HTTPRouteARecordParams<'_>) -> ARecord {
+    let mut labels = BTreeMap::new();
+    labels.insert(
+        LABEL_MANAGED_BY.to_string(),
+        LABEL_MANAGED_BY_SCOUT.to_string(),
+    );
+    labels.insert(
+        LABEL_SOURCE_CLUSTER.to_string(),
+        params.cluster_name.to_string(),
+    );
+    labels.insert(
+        LABEL_SOURCE_NAMESPACE.to_string(),
+        params.route_namespace.to_string(),
+    );
+    labels.insert(
+        LABEL_SOURCE_HTTPROUTE.to_string(),
+        params.route_name.to_string(),
+    );
+    labels.insert(LABEL_ZONE.to_string(), params.zone.to_string());
+
+    let meta = kube::api::ObjectMeta {
+        name: Some(params.name.to_string()),
+        namespace: Some(params.target_namespace.to_string()),
+        labels: Some(labels),
+        ..Default::default()
+    };
+
+    ARecord {
+        metadata: meta,
+        spec: ARecordSpec {
+            name: params.record_name.to_string(),
+            ipv4_addresses: params.ips.to_vec(),
+            ttl: params.ttl,
+        },
+        status: None,
+    }
+}
+
+/// Parameters for building an ARecord CR from a TLSRoute.
+pub struct TLSRouteARecordParams<'a> {
+    /// Kubernetes resource name for the ARecord CR
+    pub name: &'a str,
+    /// Namespace where the ARecord CR will be created
+    pub target_namespace: &'a str,
+    /// DNS record name within the zone (e.g. `"secure"`)
+    pub record_name: &'a str,
+    /// IPv4 addresses for the record
+    pub ips: &'a [String],
+    /// Optional TTL override in seconds
+    pub ttl: Option<i32>,
+    /// Logical name of the source cluster (for labels)
+    pub cluster_name: &'a str,
+    /// Source TLSRoute namespace (for labels)
+    pub route_namespace: &'a str,
+    /// Source TLSRoute name (for labels)
+    pub route_name: &'a str,
+    /// DNS zone name (for labels)
+    pub zone: &'a str,
+}
+
+/// Builds the ARecord CR that Scout will create for a TLSRoute.
+pub fn build_tlsroute_arecord(params: TLSRouteARecordParams<'_>) -> ARecord {
+    let mut labels = BTreeMap::new();
+    labels.insert(
+        LABEL_MANAGED_BY.to_string(),
+        LABEL_MANAGED_BY_SCOUT.to_string(),
+    );
+    labels.insert(
+        LABEL_SOURCE_CLUSTER.to_string(),
+        params.cluster_name.to_string(),
+    );
+    labels.insert(
+        LABEL_SOURCE_NAMESPACE.to_string(),
+        params.route_namespace.to_string(),
+    );
+    labels.insert(
+        LABEL_SOURCE_TLSROUTE.to_string(),
+        params.route_name.to_string(),
+    );
+    labels.insert(LABEL_ZONE.to_string(), params.zone.to_string());
+
+    let meta = kube::api::ObjectMeta {
+        name: Some(params.name.to_string()),
+        namespace: Some(params.target_namespace.to_string()),
+        labels: Some(labels),
+        ..Default::default()
+    };
+
+    ARecord {
+        metadata: meta,
+        spec: ARecordSpec {
+            name: params.record_name.to_string(),
+            ipv4_addresses: params.ips.to_vec(),
+            ttl: params.ttl,
+        },
+        status: None,
+    }
+}
+
+// ============================================================================
 // Finalizer helpers (async — require Kubernetes API access)
 // ============================================================================
 
@@ -646,6 +967,82 @@ async fn remove_finalizer_from_service(client: &Client, svc: &Service) -> Result
     let api: Api<Service> = Api::namespaced(client.clone(), &namespace);
 
     let finalizers: Vec<String> = svc
+        .metadata
+        .finalizers
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|f| f != FINALIZER_SCOUT)
+        .collect();
+
+    let patch = serde_json::json!({ "metadata": { "finalizers": finalizers } });
+    api.patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await?;
+    Ok(())
+}
+
+/// Adds the Scout finalizer to an HTTPRoute.
+async fn add_finalizer_to_httproute(client: &Client, route: &HTTPRoute) -> Result<()> {
+    let namespace = route.namespace().unwrap_or_default();
+    let name = route.name_any();
+    let api: Api<HTTPRoute> = Api::namespaced(client.clone(), &namespace);
+
+    let mut finalizers = route.metadata.finalizers.clone().unwrap_or_default();
+    if !finalizers.contains(&FINALIZER_SCOUT.to_string()) {
+        finalizers.push(FINALIZER_SCOUT.to_string());
+    }
+
+    let patch = serde_json::json!({ "metadata": { "finalizers": finalizers } });
+    api.patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await?;
+    Ok(())
+}
+
+/// Removes the Scout finalizer from an HTTPRoute.
+async fn remove_finalizer_from_httproute(client: &Client, route: &HTTPRoute) -> Result<()> {
+    let namespace = route.namespace().unwrap_or_default();
+    let name = route.name_any();
+    let api: Api<HTTPRoute> = Api::namespaced(client.clone(), &namespace);
+
+    let finalizers: Vec<String> = route
+        .metadata
+        .finalizers
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|f| f != FINALIZER_SCOUT)
+        .collect();
+
+    let patch = serde_json::json!({ "metadata": { "finalizers": finalizers } });
+    api.patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await?;
+    Ok(())
+}
+
+/// Adds the Scout finalizer to a TLSRoute.
+async fn add_finalizer_to_tlsroute(client: &Client, route: &TLSRoute) -> Result<()> {
+    let namespace = route.namespace().unwrap_or_default();
+    let name = route.name_any();
+    let api: Api<TLSRoute> = Api::namespaced(client.clone(), &namespace);
+
+    let mut finalizers = route.metadata.finalizers.clone().unwrap_or_default();
+    if !finalizers.contains(&FINALIZER_SCOUT.to_string()) {
+        finalizers.push(FINALIZER_SCOUT.to_string());
+    }
+
+    let patch = serde_json::json!({ "metadata": { "finalizers": finalizers } });
+    api.patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await?;
+    Ok(())
+}
+
+/// Removes the Scout finalizer from a TLSRoute.
+async fn remove_finalizer_from_tlsroute(client: &Client, route: &TLSRoute) -> Result<()> {
+    let namespace = route.namespace().unwrap_or_default();
+    let name = route.name_any();
+    let api: Api<TLSRoute> = Api::namespaced(client.clone(), &namespace);
+
+    let finalizers: Vec<String> = route
         .metadata
         .finalizers
         .clone()
@@ -754,6 +1151,110 @@ async fn delete_arecords_for_service(
             service = %svc_name,
             ns = %svc_namespace,
             "Deleted ARecord during Service cleanup"
+        );
+    }
+    Ok(())
+}
+
+/// Deletes all ARecords created by Scout for a specific HTTPRoute.
+async fn delete_arecords_for_httproute(
+    remote_client: &Client,
+    target_namespace: &str,
+    cluster: &str,
+    route_namespace: &str,
+    route_name: &str,
+) -> Result<()> {
+    let api: Api<ARecord> = Api::namespaced(remote_client.clone(), target_namespace);
+    let selector = httproute_arecord_label_selector(cluster, route_namespace, route_name);
+    let lp = ListParams::default().labels(&selector);
+
+    let arecords = api.list(&lp).await?;
+    for ar in arecords.items {
+        let ar_name = ar.name_any();
+        api.delete(&ar_name, &DeleteParams::default()).await?;
+        info!(
+            arecord = %ar_name,
+            httproute = %route_name,
+            ns = %route_namespace,
+            "Deleted ARecord during HTTPRoute cleanup"
+        );
+    }
+    Ok(())
+}
+
+/// Deletes all ARecords created by Scout for a specific TLSRoute.
+async fn delete_arecords_for_tlsroute(
+    remote_client: &Client,
+    target_namespace: &str,
+    cluster: &str,
+    route_namespace: &str,
+    route_name: &str,
+) -> Result<()> {
+    let api: Api<ARecord> = Api::namespaced(remote_client.clone(), target_namespace);
+    let selector = tlsroute_arecord_label_selector(cluster, route_namespace, route_name);
+    let lp = ListParams::default().labels(&selector);
+
+    let arecords = api.list(&lp).await?;
+    for ar in arecords.items {
+        let ar_name = ar.name_any();
+        api.delete(&ar_name, &DeleteParams::default()).await?;
+        info!(
+            arecord = %ar_name,
+            tlsroute = %route_name,
+            ns = %route_namespace,
+            "Deleted ARecord during TLSRoute cleanup"
+        );
+    }
+    Ok(())
+}
+
+/// Deletes stale ARecords for an HTTPRoute from previous cluster names.
+async fn delete_stale_cluster_httproute_arecords(
+    remote_client: &Client,
+    target_namespace: &str,
+    current_cluster: &str,
+    route_namespace: &str,
+    route_name: &str,
+) -> Result<()> {
+    let api: Api<ARecord> = Api::namespaced(remote_client.clone(), target_namespace);
+    let selector =
+        stale_httproute_arecord_label_selector(current_cluster, route_namespace, route_name);
+    let lp = ListParams::default().labels(&selector);
+
+    let arecords = api.list(&lp).await?;
+    for ar in arecords.items {
+        let ar_name = ar.name_any();
+        api.delete(&ar_name, &DeleteParams::default()).await?;
+        info!(
+            arecord = %ar_name,
+            httproute = %route_name,
+            "Deleted stale HTTPRoute ARecord from previous cluster name"
+        );
+    }
+    Ok(())
+}
+
+/// Deletes stale ARecords for a TLSRoute from previous cluster names.
+async fn delete_stale_cluster_tlsroute_arecords(
+    remote_client: &Client,
+    target_namespace: &str,
+    current_cluster: &str,
+    route_namespace: &str,
+    route_name: &str,
+) -> Result<()> {
+    let api: Api<ARecord> = Api::namespaced(remote_client.clone(), target_namespace);
+    let selector =
+        stale_tlsroute_arecord_label_selector(current_cluster, route_namespace, route_name);
+    let lp = ListParams::default().labels(&selector);
+
+    let arecords = api.list(&lp).await?;
+    for ar in arecords.items {
+        let ar_name = ar.name_any();
+        api.delete(&ar_name, &DeleteParams::default()).await?;
+        info!(
+            arecord = %ar_name,
+            tlsroute = %route_name,
+            "Deleted stale TLSRoute ARecord from previous cluster name"
         );
     }
     Ok(())
@@ -1193,6 +1694,510 @@ fn error_policy(_obj: Arc<Ingress>, error: &ScoutError, _ctx: Arc<ScoutContext>)
 }
 
 // ============================================================================
+// Gateway API (HTTPRoute / TLSRoute) Reconciliation
+//
+// Note: HTTPRoute and TLSRoute reconciliation follows the same pattern as
+// Ingress reconciliation, with these differences:
+//
+// 1. HTTPRoute sources: `spec.hostnames[]` (array) instead of `spec.rules[].host`
+// 2. TLSRoute sources: `spec.hostnames[]` (array) instead of routes with hosts
+// 3. One ARecord per hostname with index suffix (like Ingress has one per rule)
+// 4. Zone and IP resolution use the same annotation scheme as Ingress/Service
+// ============================================================================
+
+/// Reconciles a single `HTTPRoute` resource, creating or updating ARecord CRs as needed.
+///
+/// Mirrors the Ingress reconciler lifecycle:
+/// - Opts in via `bindy.firestoned.io/scout-enabled: "true"`.
+/// - Adds a finalizer; on deletion removes ARecords and releases it.
+/// - If the opt-in annotation is removed, cleans up ARecords and finalizer.
+/// - One ARecord created per hostname in `spec.hostnames[]` with an index suffix.
+/// - Re-queues if zone is not found or no IP is available yet.
+///
+/// # Errors
+///
+/// Returns `ScoutError` if API calls fail (apply, delete, patch).
+async fn reconcile_httproute(
+    route: Arc<HTTPRoute>,
+    ctx: Arc<ScoutContext>,
+) -> Result<Action, ScoutError> {
+    let name = route.name_any();
+    let namespace = route.namespace().unwrap_or_default();
+
+    // Guard: Skip excluded namespaces
+    if ctx.excluded_namespaces.contains(&namespace) {
+        debug!(httproute = %name, ns = %namespace, "Skipping excluded namespace");
+        return Ok(Action::await_change());
+    }
+
+    // Handle HTTPRoute deletion — remove ARecords and release the finalizer
+    if route.metadata.deletion_timestamp.is_some() {
+        if route
+            .metadata
+            .finalizers
+            .as_ref()
+            .map(|fs| fs.iter().any(|f| f == FINALIZER_SCOUT))
+            .unwrap_or(false)
+        {
+            info!(httproute = %name, ns = %namespace, "HTTPRoute deleting — cleaning up ARecords");
+            delete_arecords_for_httproute(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            delete_stale_cluster_httproute_arecords(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            remove_finalizer_from_httproute(&ctx.client, &route)
+                .await
+                .map_err(ScoutError::from)?;
+            info!(httproute = %name, ns = %namespace, "Finalizer removed — HTTPRoute deletion unblocked");
+        }
+        return Ok(Action::await_change());
+    }
+
+    let annotations = route
+        .metadata
+        .annotations
+        .as_ref()
+        .cloned()
+        .unwrap_or_default();
+
+    // Guard: opt-in annotation required
+    if !is_scout_opted_in(&annotations) {
+        let has_fin = route
+            .metadata
+            .finalizers
+            .as_ref()
+            .map(|fs| fs.iter().any(|f| f == FINALIZER_SCOUT))
+            .unwrap_or(false);
+        if has_fin {
+            info!(httproute = %name, ns = %namespace, "Scout opt-in annotation removed — cleaning up ARecords and finalizer");
+            delete_arecords_for_httproute(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            delete_stale_cluster_httproute_arecords(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            remove_finalizer_from_httproute(&ctx.client, &route)
+                .await
+                .map_err(ScoutError::from)?;
+        }
+        debug!(httproute = %name, ns = %namespace, "No scout-enabled annotation — skipping");
+        return Ok(Action::await_change());
+    }
+
+    // Ensure finalizer before creating any ARecord
+    let has_fin = route
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|fs| fs.iter().any(|f| f == FINALIZER_SCOUT))
+        .unwrap_or(false);
+    if !has_fin {
+        add_finalizer_to_httproute(&ctx.client, &route)
+            .await
+            .map_err(ScoutError::from)?;
+        debug!(httproute = %name, ns = %namespace, "Finalizer added — re-queuing for record creation");
+        return Ok(Action::await_change());
+    }
+
+    // Guard: zone required
+    let zone = match resolve_zone(&annotations, ctx.default_zone.as_deref()) {
+        Some(z) => z,
+        None => {
+            warn!(httproute = %name, ns = %namespace, "No DNS zone available — skipping");
+            return Ok(Action::requeue(Duration::from_secs(
+                SCOUT_ERROR_REQUEUE_SECS,
+            )));
+        }
+    };
+
+    // Guard: zone must exist in the DNSZone store
+    let zone_exists = ctx
+        .zone_store
+        .state()
+        .iter()
+        .any(|z| z.spec.zone_name == zone);
+    if !zone_exists {
+        warn!(httproute = %name, ns = %namespace, zone = %zone, "Zone not found in DNSZone store — requeuing");
+        return Ok(Action::requeue(Duration::from_secs(
+            SCOUT_ERROR_REQUEUE_SECS,
+        )));
+    }
+
+    // Resolve IPs: annotation → default_ips → no routable IP = requeue
+    let ips = {
+        let from_annotation = annotations
+            .get(ANNOTATION_IP)
+            .filter(|v| !v.is_empty())
+            .map(|v| vec![v.clone()]);
+        let from_defaults = if ctx.default_ips.is_empty() {
+            None
+        } else {
+            Some(ctx.default_ips.clone())
+        };
+
+        match from_annotation.or(from_defaults) {
+            Some(ips) => ips,
+            None => {
+                warn!(httproute = %name, ns = %namespace, "No IP available (no annotation override, no default IPs) — requeuing");
+                return Ok(Action::requeue(Duration::from_secs(
+                    SCOUT_ERROR_REQUEUE_SECS,
+                )));
+            }
+        }
+    };
+
+    let ttl: Option<i32> = annotations.get(ANNOTATION_TTL).and_then(|v| v.parse().ok());
+
+    // Extract hostnames from spec.hostnames[]
+    let hostnames = route
+        .spec
+        .as_ref()
+        .and_then(|s| s.hostnames.as_ref())
+        .cloned()
+        .unwrap_or_default();
+
+    let arecord_api: Api<ARecord> =
+        Api::namespaced(ctx.remote_client.clone(), &ctx.target_namespace);
+
+    for (idx, hostname) in hostnames.iter().enumerate() {
+        if hostname.is_empty() {
+            debug!(httproute = %name, hostname_index = idx, "HTTPRoute hostname is empty — skipping");
+            continue;
+        }
+
+        let record_name = match derive_record_name(hostname, &zone) {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(httproute = %name, hostname = %hostname, zone = %zone, error = %e, "Hostname does not belong to zone — skipping");
+                continue;
+            }
+        };
+
+        let cr_name = httproute_arecord_cr_name(&ctx.cluster_name, &namespace, &name, idx);
+        let arecord = build_httproute_arecord(HTTPRouteARecordParams {
+            name: &cr_name,
+            target_namespace: &ctx.target_namespace,
+            record_name: &record_name,
+            ips: &ips,
+            ttl,
+            cluster_name: &ctx.cluster_name,
+            route_namespace: &namespace,
+            route_name: &name,
+            zone: &zone,
+        });
+
+        // Server-side apply
+        let ssapply = kube::api::PatchParams::apply("bindy-scout").force();
+        match arecord_api
+            .patch(&cr_name, &ssapply, &kube::api::Patch::Apply(&arecord))
+            .await
+        {
+            Ok(_) => {
+                info!(arecord = %cr_name, httproute = %name, hostname = %hostname, ips = ?ips, "ARecord created/updated for HTTPRoute");
+            }
+            Err(e) => {
+                error!(arecord = %cr_name, httproute = %name, error = %e, "Failed to apply ARecord for HTTPRoute");
+                return Err(ScoutError::from(anyhow!(
+                    "Failed to apply ARecord {cr_name}: {e}"
+                )));
+            }
+        }
+    }
+
+    // Clean up stale ARecords from old cluster names
+    delete_stale_cluster_httproute_arecords(
+        &ctx.remote_client,
+        &ctx.target_namespace,
+        &ctx.cluster_name,
+        &namespace,
+        &name,
+    )
+    .await
+    .map_err(ScoutError::from)?;
+
+    Ok(Action::await_change())
+}
+
+/// Reconciles a single `TLSRoute` resource, creating or updating ARecord CRs as needed.
+///
+/// Identical to HTTPRoute reconciliation: both resources have `spec.hostnames[]`
+/// and use the same annotation/IP resolution scheme.
+///
+/// # Errors
+///
+/// Returns `ScoutError` if API calls fail.
+async fn reconcile_tlsroute(
+    route: Arc<TLSRoute>,
+    ctx: Arc<ScoutContext>,
+) -> Result<Action, ScoutError> {
+    let name = route.name_any();
+    let namespace = route.namespace().unwrap_or_default();
+
+    // Guard: Skip excluded namespaces
+    if ctx.excluded_namespaces.contains(&namespace) {
+        debug!(tlsroute = %name, ns = %namespace, "Skipping excluded namespace");
+        return Ok(Action::await_change());
+    }
+
+    // Handle TLSRoute deletion — remove ARecords and release the finalizer
+    if route.metadata.deletion_timestamp.is_some() {
+        if route
+            .metadata
+            .finalizers
+            .as_ref()
+            .map(|fs| fs.iter().any(|f| f == FINALIZER_SCOUT))
+            .unwrap_or(false)
+        {
+            info!(tlsroute = %name, ns = %namespace, "TLSRoute deleting — cleaning up ARecords");
+            delete_arecords_for_tlsroute(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            delete_stale_cluster_tlsroute_arecords(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            remove_finalizer_from_tlsroute(&ctx.client, &route)
+                .await
+                .map_err(ScoutError::from)?;
+            info!(tlsroute = %name, ns = %namespace, "Finalizer removed — TLSRoute deletion unblocked");
+        }
+        return Ok(Action::await_change());
+    }
+
+    let annotations = route
+        .metadata
+        .annotations
+        .as_ref()
+        .cloned()
+        .unwrap_or_default();
+
+    // Guard: opt-in annotation required
+    if !is_scout_opted_in(&annotations) {
+        let has_fin = route
+            .metadata
+            .finalizers
+            .as_ref()
+            .map(|fs| fs.iter().any(|f| f == FINALIZER_SCOUT))
+            .unwrap_or(false);
+        if has_fin {
+            info!(tlsroute = %name, ns = %namespace, "Scout opt-in annotation removed — cleaning up ARecords and finalizer");
+            delete_arecords_for_tlsroute(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            delete_stale_cluster_tlsroute_arecords(
+                &ctx.remote_client,
+                &ctx.target_namespace,
+                &ctx.cluster_name,
+                &namespace,
+                &name,
+            )
+            .await
+            .map_err(ScoutError::from)?;
+            remove_finalizer_from_tlsroute(&ctx.client, &route)
+                .await
+                .map_err(ScoutError::from)?;
+        }
+        debug!(tlsroute = %name, ns = %namespace, "No scout-enabled annotation — skipping");
+        return Ok(Action::await_change());
+    }
+
+    // Ensure finalizer before creating any ARecord
+    let has_fin = route
+        .metadata
+        .finalizers
+        .as_ref()
+        .map(|fs| fs.iter().any(|f| f == FINALIZER_SCOUT))
+        .unwrap_or(false);
+    if !has_fin {
+        add_finalizer_to_tlsroute(&ctx.client, &route)
+            .await
+            .map_err(ScoutError::from)?;
+        debug!(tlsroute = %name, ns = %namespace, "Finalizer added — re-queuing for record creation");
+        return Ok(Action::await_change());
+    }
+
+    // Guard: zone required
+    let zone = match resolve_zone(&annotations, ctx.default_zone.as_deref()) {
+        Some(z) => z,
+        None => {
+            warn!(tlsroute = %name, ns = %namespace, "No DNS zone available — skipping");
+            return Ok(Action::requeue(Duration::from_secs(
+                SCOUT_ERROR_REQUEUE_SECS,
+            )));
+        }
+    };
+
+    // Guard: zone must exist in the DNSZone store
+    let zone_exists = ctx
+        .zone_store
+        .state()
+        .iter()
+        .any(|z| z.spec.zone_name == zone);
+    if !zone_exists {
+        warn!(tlsroute = %name, ns = %namespace, zone = %zone, "Zone not found in DNSZone store — requeuing");
+        return Ok(Action::requeue(Duration::from_secs(
+            SCOUT_ERROR_REQUEUE_SECS,
+        )));
+    }
+
+    // Resolve IPs: annotation → default_ips → no routable IP = requeue
+    let ips = {
+        let from_annotation = annotations
+            .get(ANNOTATION_IP)
+            .filter(|v| !v.is_empty())
+            .map(|v| vec![v.clone()]);
+        let from_defaults = if ctx.default_ips.is_empty() {
+            None
+        } else {
+            Some(ctx.default_ips.clone())
+        };
+
+        match from_annotation.or(from_defaults) {
+            Some(ips) => ips,
+            None => {
+                warn!(tlsroute = %name, ns = %namespace, "No IP available (no annotation override, no default IPs) — requeuing");
+                return Ok(Action::requeue(Duration::from_secs(
+                    SCOUT_ERROR_REQUEUE_SECS,
+                )));
+            }
+        }
+    };
+
+    let ttl: Option<i32> = annotations.get(ANNOTATION_TTL).and_then(|v| v.parse().ok());
+
+    // Extract hostnames from spec.hostnames[]
+    let hostnames = route
+        .spec
+        .as_ref()
+        .and_then(|s| s.hostnames.as_ref())
+        .cloned()
+        .unwrap_or_default();
+
+    let arecord_api: Api<ARecord> =
+        Api::namespaced(ctx.remote_client.clone(), &ctx.target_namespace);
+
+    for (idx, hostname) in hostnames.iter().enumerate() {
+        if hostname.is_empty() {
+            debug!(tlsroute = %name, hostname_index = idx, "TLSRoute hostname is empty — skipping");
+            continue;
+        }
+
+        let record_name = match derive_record_name(hostname, &zone) {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(tlsroute = %name, hostname = %hostname, zone = %zone, error = %e, "Hostname does not belong to zone — skipping");
+                continue;
+            }
+        };
+
+        let cr_name = tlsroute_arecord_cr_name(&ctx.cluster_name, &namespace, &name, idx);
+        let arecord = build_tlsroute_arecord(TLSRouteARecordParams {
+            name: &cr_name,
+            target_namespace: &ctx.target_namespace,
+            record_name: &record_name,
+            ips: &ips,
+            ttl,
+            cluster_name: &ctx.cluster_name,
+            route_namespace: &namespace,
+            route_name: &name,
+            zone: &zone,
+        });
+
+        // Server-side apply
+        let ssapply = kube::api::PatchParams::apply("bindy-scout").force();
+        match arecord_api
+            .patch(&cr_name, &ssapply, &kube::api::Patch::Apply(&arecord))
+            .await
+        {
+            Ok(_) => {
+                info!(arecord = %cr_name, tlsroute = %name, hostname = %hostname, ips = ?ips, "ARecord created/updated for TLSRoute");
+            }
+            Err(e) => {
+                error!(arecord = %cr_name, tlsroute = %name, error = %e, "Failed to apply ARecord for TLSRoute");
+                return Err(ScoutError::from(anyhow!(
+                    "Failed to apply ARecord {cr_name}: {e}"
+                )));
+            }
+        }
+    }
+
+    // Clean up stale ARecords from old cluster names
+    delete_stale_cluster_tlsroute_arecords(
+        &ctx.remote_client,
+        &ctx.target_namespace,
+        &ctx.cluster_name,
+        &namespace,
+        &name,
+    )
+    .await
+    .map_err(ScoutError::from)?;
+
+    Ok(Action::await_change())
+}
+
+/// Error policy for Gateway API routes: requeue with a fixed backoff.
+fn gateway_route_error_policy(
+    _obj: Arc<HTTPRoute>,
+    error: &ScoutError,
+    _ctx: Arc<ScoutContext>,
+) -> Action {
+    error!(error = %error, "Scout HTTPRoute reconcile error — requeuing");
+    Action::requeue(Duration::from_secs(SCOUT_ERROR_REQUEUE_SECS))
+}
+
+/// Error policy for TLSRoute: requeue with a fixed backoff.
+fn tlsroute_error_policy(
+    _obj: Arc<TLSRoute>,
+    error: &ScoutError,
+    _ctx: Arc<ScoutContext>,
+) -> Action {
+    error!(error = %error, "Scout TLSRoute reconcile error — requeuing");
+    Action::requeue(Duration::from_secs(SCOUT_ERROR_REQUEUE_SECS))
+}
+
+// ============================================================================
 // Remote client builder (Phase 2)
 // ============================================================================
 
@@ -1478,8 +2483,12 @@ pub async fn run_scout(
     let ingress_api: Api<Ingress> = Api::all(local_client.clone());
     // Watch Services across all namespaces using the LOCAL client
     let svc_api: Api<Service> = Api::all(local_client.clone());
+    // Watch HTTPRoutes across all namespaces using the LOCAL client
+    let httproute_api: Api<HTTPRoute> = Api::all(local_client.clone());
+    // Watch TLSRoutes across all namespaces using the LOCAL client
+    let tlsroute_api: Api<TLSRoute> = Api::all(local_client.clone());
 
-    info!("Scout controller running — watching Ingresses and Services");
+    info!("Scout controller running — watching Ingresses, Services, HTTPRoutes, and TLSRoutes");
 
     let ingress_controller = Controller::new(ingress_api, WatcherConfig::default())
         .run(reconcile, error_policy, ctx.clone())
@@ -1491,7 +2500,7 @@ pub async fn run_scout(
         });
 
     let service_controller = Controller::new(svc_api, WatcherConfig::default())
-        .run(reconcile_service, service_error_policy, ctx)
+        .run(reconcile_service, service_error_policy, ctx.clone())
         .for_each(|res| async move {
             match res {
                 Ok(obj) => debug!(obj = ?obj, "Reconciled Service"),
@@ -1499,7 +2508,31 @@ pub async fn run_scout(
             }
         });
 
-    futures::future::join(ingress_controller, service_controller).await;
+    let httproute_controller = Controller::new(httproute_api, WatcherConfig::default())
+        .run(reconcile_httproute, gateway_route_error_policy, ctx.clone())
+        .for_each(|res| async move {
+            match res {
+                Ok(obj) => debug!(obj = ?obj, "Reconciled HTTPRoute"),
+                Err(e) => error!(error = %e, "HTTPRoute reconcile failed"),
+            }
+        });
+
+    let tlsroute_controller = Controller::new(tlsroute_api, WatcherConfig::default())
+        .run(reconcile_tlsroute, tlsroute_error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok(obj) => debug!(obj = ?obj, "Reconciled TLSRoute"),
+                Err(e) => error!(error = %e, "TLSRoute reconcile failed"),
+            }
+        });
+
+    futures::future::join4(
+        ingress_controller,
+        service_controller,
+        httproute_controller,
+        tlsroute_controller,
+    )
+    .await;
 
     Ok(())
 }

--- a/src/scout_tests.rs
+++ b/src/scout_tests.rs
@@ -804,4 +804,319 @@ mod tests {
         assert_eq!(arecord.spec.ipv4_addresses, vec!["1.2.3.4".to_string()]);
         assert_eq!(arecord.spec.ttl, None);
     }
+
+    // =========================================================================
+    // HTTPRoute & TLSRoute (Gateway API) — Phase 2 feature
+    // =========================================================================
+
+    #[test]
+    fn test_httproute_arecord_cr_name_single_hostname() {
+        // Arrange & Act
+        let name = crate::scout::httproute_arecord_cr_name("prod", "default", "api-route", 0);
+
+        // Assert
+        assert!(name.starts_with("scout-"));
+        assert!(name.contains("prod"));
+        assert!(name.contains("default"));
+        assert!(name.contains("api-route"));
+        assert!(name.contains("0")); // index suffix
+        assert!(!name.ends_with('-'));
+        assert!(name.len() <= 253); // K8s name length limit
+    }
+
+    #[test]
+    fn test_httproute_arecord_cr_name_multiple_indices() {
+        // Arrange & Act
+        let name0 = crate::scout::httproute_arecord_cr_name("prod", "default", "api-route", 0);
+        let name1 = crate::scout::httproute_arecord_cr_name("prod", "default", "api-route", 1);
+        let name2 = crate::scout::httproute_arecord_cr_name("prod", "default", "api-route", 2);
+
+        // Assert — each index produces a different CR name
+        assert_ne!(name0, name1);
+        assert_ne!(name1, name2);
+        // Verify indices are in the names
+        assert!(name0.contains("0"));
+        assert!(name1.contains("1"));
+        assert!(name2.contains("2"));
+    }
+
+    #[test]
+    fn test_httproute_arecord_cr_name_sanitization() {
+        // Arrange & Act
+        let name =
+            crate::scout::httproute_arecord_cr_name("prod_cluster", "kube-system", "My-Route", 5);
+
+        // Assert — underscores and uppercase should be sanitized
+        assert!(!name.contains("_"));
+        assert!(!name.contains('K'));
+        assert!(!name.contains('M'));
+        assert!(!name.ends_with('-'));
+    }
+
+    #[test]
+    fn test_tlsroute_arecord_cr_name_single_hostname() {
+        // Arrange & Act
+        let name = crate::scout::tlsroute_arecord_cr_name("prod", "default", "secure-route", 0);
+
+        // Assert
+        assert!(name.starts_with("scout-"));
+        assert!(name.contains("prod"));
+        assert!(name.contains("default"));
+        assert!(name.contains("secure-route"));
+        assert!(name.contains("0"));
+        assert!(!name.ends_with('-'));
+        assert!(name.len() <= 253);
+    }
+
+    #[test]
+    fn test_tlsroute_arecord_cr_name_multiple_indices() {
+        // Arrange & Act
+        let name0 = crate::scout::tlsroute_arecord_cr_name("prod", "default", "secure-route", 0);
+        let name1 = crate::scout::tlsroute_arecord_cr_name("prod", "default", "secure-route", 1);
+
+        // Assert
+        assert_ne!(name0, name1);
+        assert!(name0.contains("0"));
+        assert!(name1.contains("1"));
+    }
+
+    #[test]
+    fn test_httproute_arecord_label_selector() {
+        // Arrange & Act
+        let selector =
+            crate::scout::httproute_arecord_label_selector("prod", "default", "api-route");
+
+        // Assert
+        assert!(selector.contains(LABEL_MANAGED_BY));
+        assert!(selector.contains(LABEL_MANAGED_BY_SCOUT));
+        assert!(selector.contains("prod"));
+        assert!(selector.contains("default"));
+        assert!(selector.contains("api-route"));
+        // Verify it has the source-httproute label (different from source-ingress)
+        assert!(selector.contains("source-httproute"));
+    }
+
+    #[test]
+    fn test_tlsroute_arecord_label_selector() {
+        // Arrange & Act
+        let selector =
+            crate::scout::tlsroute_arecord_label_selector("prod", "default", "secure-route");
+
+        // Assert
+        assert!(selector.contains(LABEL_MANAGED_BY));
+        assert!(selector.contains(LABEL_MANAGED_BY_SCOUT));
+        assert!(selector.contains("prod"));
+        assert!(selector.contains("default"));
+        assert!(selector.contains("secure-route"));
+        // Verify it has the source-tlsroute label
+        assert!(selector.contains("source-tlsroute"));
+    }
+
+    #[test]
+    fn test_httproute_arecord_label_selector_distinct_from_tlsroute() {
+        // Arrange & Act
+        let http_selector =
+            crate::scout::httproute_arecord_label_selector("prod", "default", "route");
+        let tls_selector =
+            crate::scout::tlsroute_arecord_label_selector("prod", "default", "route");
+
+        // Assert — they must differ because they target different route types
+        assert_ne!(http_selector, tls_selector);
+    }
+
+    #[test]
+    fn test_stale_httproute_arecord_label_selector_uses_not_equal() {
+        // Arrange & Act
+        let selector = crate::scout::stale_httproute_arecord_label_selector(
+            "new-cluster",
+            "default",
+            "api-route",
+        );
+
+        // Assert
+        assert!(selector.contains(&format!("{}!=new-cluster", LABEL_SOURCE_CLUSTER)));
+        assert!(selector.contains("source-httproute"));
+        assert!(selector.contains("default"));
+        assert!(selector.contains("api-route"));
+    }
+
+    #[test]
+    fn test_stale_tlsroute_arecord_label_selector_uses_not_equal() {
+        // Arrange & Act
+        let selector = crate::scout::stale_tlsroute_arecord_label_selector(
+            "new-cluster",
+            "default",
+            "secure-route",
+        );
+
+        // Assert
+        assert!(selector.contains(&format!("{}!=new-cluster", LABEL_SOURCE_CLUSTER)));
+        assert!(selector.contains("source-tlsroute"));
+        assert!(selector.contains("default"));
+        assert!(selector.contains("secure-route"));
+    }
+
+    #[test]
+    fn test_build_httproute_arecord_sets_expected_labels() {
+        // Arrange
+        let params = crate::scout::HTTPRouteARecordParams {
+            name: "scout-prod-default-api-route-0",
+            target_namespace: "bindy-system",
+            record_name: "api",
+            ips: &["10.0.0.1".to_string()],
+            ttl: Some(300),
+            cluster_name: "prod",
+            route_namespace: "default",
+            route_name: "api-route",
+            zone: "example.com",
+        };
+
+        // Act
+        let arecord = crate::scout::build_httproute_arecord(params);
+
+        // Assert
+        let labels = arecord.metadata.labels.as_ref().unwrap();
+        assert_eq!(
+            labels.get(LABEL_MANAGED_BY).map(String::as_str),
+            Some(LABEL_MANAGED_BY_SCOUT)
+        );
+        assert_eq!(
+            labels.get(LABEL_SOURCE_CLUSTER).map(String::as_str),
+            Some("prod")
+        );
+        assert_eq!(
+            labels.get(LABEL_SOURCE_NAMESPACE).map(String::as_str),
+            Some("default")
+        );
+        // Must use "source-httproute" label, not "source-ingress"
+        assert_eq!(
+            labels
+                .get("bindy.firestoned.io/source-httproute")
+                .map(String::as_str),
+            Some("api-route")
+        );
+        assert_eq!(
+            labels.get(LABEL_ZONE).map(String::as_str),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn test_build_httproute_arecord_uses_record_name_in_spec() {
+        // Arrange
+        let params = crate::scout::HTTPRouteARecordParams {
+            name: "scout-prod-default-api-route-0",
+            target_namespace: "bindy-system",
+            record_name: "api",
+            ips: &["1.2.3.4".to_string()],
+            ttl: None,
+            cluster_name: "prod",
+            route_namespace: "default",
+            route_name: "api-route",
+            zone: "example.com",
+        };
+
+        // Act
+        let arecord = crate::scout::build_httproute_arecord(params);
+
+        // Assert
+        assert_eq!(arecord.spec.name, "api");
+        assert_eq!(arecord.spec.ipv4_addresses, vec!["1.2.3.4".to_string()]);
+        assert_eq!(arecord.spec.ttl, None);
+    }
+
+    #[test]
+    fn test_build_tlsroute_arecord_sets_expected_labels() {
+        // Arrange
+        let params = crate::scout::TLSRouteARecordParams {
+            name: "scout-prod-default-secure-route-0",
+            target_namespace: "bindy-system",
+            record_name: "secure",
+            ips: &["10.0.0.2".to_string()],
+            ttl: Some(600),
+            cluster_name: "prod",
+            route_namespace: "default",
+            route_name: "secure-route",
+            zone: "example.com",
+        };
+
+        // Act
+        let arecord = crate::scout::build_tlsroute_arecord(params);
+
+        // Assert
+        let labels = arecord.metadata.labels.as_ref().unwrap();
+        assert_eq!(
+            labels.get(LABEL_MANAGED_BY).map(String::as_str),
+            Some(LABEL_MANAGED_BY_SCOUT)
+        );
+        assert_eq!(
+            labels.get(LABEL_SOURCE_CLUSTER).map(String::as_str),
+            Some("prod")
+        );
+        // Must use "source-tlsroute" label
+        assert_eq!(
+            labels
+                .get("bindy.firestoned.io/source-tlsroute")
+                .map(String::as_str),
+            Some("secure-route")
+        );
+        assert_eq!(
+            labels.get(LABEL_ZONE).map(String::as_str),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn test_build_tlsroute_arecord_uses_record_name_in_spec() {
+        // Arrange
+        let params = crate::scout::TLSRouteARecordParams {
+            name: "scout-prod-default-secure-route-0",
+            target_namespace: "bindy-system",
+            record_name: "secure",
+            ips: &["5.6.7.8".to_string()],
+            ttl: Some(900),
+            cluster_name: "prod",
+            route_namespace: "default",
+            route_name: "secure-route",
+            zone: "example.com",
+        };
+
+        // Act
+        let arecord = crate::scout::build_tlsroute_arecord(params);
+
+        // Assert
+        assert_eq!(arecord.spec.name, "secure");
+        assert_eq!(arecord.spec.ipv4_addresses, vec!["5.6.7.8".to_string()]);
+        assert_eq!(arecord.spec.ttl, Some(900));
+    }
+
+    #[test]
+    fn test_httproute_arecord_cr_name_respects_length_limit() {
+        // Arrange — a very long HTTPRoute name
+        let long_route_name = "my-long-route-name-that-is-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long";
+
+        // Act
+        let name = crate::scout::httproute_arecord_cr_name("prod", "default", long_route_name, 99);
+
+        // Assert
+        assert!(
+            name.len() <= 253,
+            "HTTPRoute CR name must not exceed 253 chars"
+        );
+    }
+
+    #[test]
+    fn test_tlsroute_arecord_cr_name_respects_length_limit() {
+        // Arrange — a very long TLSRoute name
+        let long_route_name = "my-long-route-name-that-is-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long";
+
+        // Act
+        let name = crate::scout::tlsroute_arecord_cr_name("prod", "default", long_route_name, 99);
+
+        // Assert
+        assert!(
+            name.len() <= 253,
+            "TLSRoute CR name must not exceed 253 chars"
+        );
+    }
 }


### PR DESCRIPTION
**Summary**
Scout can now automatically create DNS A records for Kubernetes Gateway API resources (HTTPRoute and TLSRoute), enabling DNS management for advanced routing use cases beyond traditional Ingress resources.

This implementation mirrors Scout's existing Ingress/Service reconciliation pattern, providing consistent DNS automation across all gateway types.

**Motivation**
The Gateway API (stable v1) is the modern Kubernetes standard for sophisticated routing, multi-protocol support, and cross-namespace traffic management. Organizations using HTTPRoute for advanced HTTP routing or TLSRoute for non-HTTP protocols (gRPC, TCP/TLS) now have automatic DNS integration with Bindy.