### PR TITLE
Change the scout source label to be ubiquitous across the different "kinds", just source-name

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [2026-03-29] - Unify Scout source labels into bindy.firestoned.io/source-name
+
+**Author:** Erick Bourgeois
+
+### Changed
+- `src/scout.rs`: Replaced four constants (`LABEL_SOURCE_INGRESS`, `LABEL_SOURCE_SERVICE`, `LABEL_SOURCE_HTTPROUTE`, `LABEL_SOURCE_TLSROUTE`) with a single `LABEL_SOURCE_NAME = "bindy.firestoned.io/source-name"`. All builder functions and label selector functions updated.
+- `src/scout_tests.rs`: Updated all test imports and assertions; removed now-invalid negative assertions; updated selector-equality test for HTTPRoute/TLSRoute.
+- `docs/src/guide/scout.md`, `docs/src/installation/scout.md`: Updated all labels tables and kubectl examples.
+- `examples/httproute-dns.yaml`, `examples/tlsroute-dns.yaml`: Updated comment kubectl examples.
+
+### Why
+The per-kind labels were redundant — the kind is already in the resource metadata. One `source-name` label is simpler to query.
+
+### Impact
+- [x] Breaking change — existing `DNSZone.spec.recordsFrom` label selectors or tooling using the old `source-ingress`/`source-service`/`source-httproute`/`source-tlsroute` labels must be updated to `source-name`
+- [x] Requires cluster rollout
+
+---
+
 ## [2026-03-29] - Document Gateway API support in Scout guides
 
 **Author:** Erick Bourgeois

--- a/docs/roadmaps/bindy-scout-ingress-controller.md
+++ b/docs/roadmaps/bindy-scout-ingress-controller.md
@@ -167,7 +167,7 @@ labels:
   bindy.firestoned.io/managed-by: scout
   bindy.firestoned.io/source-cluster: "<BINDY_SCOUT_CLUSTER_NAME>"
   bindy.firestoned.io/source-namespace: "<ingress-namespace>"
-  bindy.firestoned.io/source-ingress: "<ingress-name>"
+  bindy.firestoned.io/source-name: "<ingress-name>"
   # zone label so bindy's DNSZone selector can pick it up:
   bindy.firestoned.io/zone: "example.com"
 ```

--- a/docs/src/guide/scout.md
+++ b/docs/src/guide/scout.md
@@ -118,7 +118,7 @@ Scout will create an `ARecord` named `scout-<cluster>-my-app-ns-my-app-0` in the
 
 - `spec.name`: `my-app` (derived by stripping the zone suffix from the host)
 - `spec.address`: IP from the Ingress LoadBalancer status
-- Labels: `bindy.firestoned.io/source-cluster`, `source-namespace`, `source-ingress`, `zone`
+- Labels: `bindy.firestoned.io/source-cluster`, `source-namespace`, `source-name`, `zone`
 
 **For a LoadBalancer Service:**
 
@@ -274,12 +274,12 @@ WARN scout: service my-app/my-grpc-api has no external IP yet; requeueing in 30s
 | ARecord per rule | Yes (one per `rules[].host`) | No — exactly one record |
 | CR name suffix | `...-{idx}` (rule index) | No index |
 | IP source | LB status or annotation | LB status or annotation |
-| Source label | `source-ingress` | `source-service` |
+| Source label | `source-name` | `source-name` |
 
 Query all Service-sourced ARecords:
 
 ```bash
-kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-service
+kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-name=<service-name>
 ```
 
 ---
@@ -304,10 +304,7 @@ Every `ARecord` created by Scout carries these labels:
 | `bindy.firestoned.io/managed-by` | `scout` | All |
 | `bindy.firestoned.io/source-cluster` | `<BINDY_SCOUT_CLUSTER_NAME>` | All |
 | `bindy.firestoned.io/source-namespace` | Resource namespace | All |
-| `bindy.firestoned.io/source-ingress` | Ingress name | Ingress only |
-| `bindy.firestoned.io/source-service` | Service name | Service only |
-| `bindy.firestoned.io/source-httproute` | HTTPRoute name | HTTPRoute only |
-| `bindy.firestoned.io/source-tlsroute` | TLSRoute name | TLSRoute only |
+| `bindy.firestoned.io/source-name` | Resource name | All |
 | `bindy.firestoned.io/zone` | Zone name | All |
 
 The `zone` label is particularly important: it lets you configure a `DNSZone` to automatically pull in all ARecords created by Scout for that zone:
@@ -589,8 +586,7 @@ ARecords created from Gateway API routes carry similar labels to Ingress-derived
 | `bindy.firestoned.io/managed-by` | `scout` | Identifies Scout as the manager |
 | `bindy.firestoned.io/source-cluster` | `<BINDY_SCOUT_CLUSTER_NAME>` | Cluster where the route lives |
 | `bindy.firestoned.io/source-namespace` | Route namespace | Source namespace for traceability |
-| `bindy.firestoned.io/source-httproute` | Route name | **(HTTPRoute only)** Source HTTPRoute name |
-| `bindy.firestoned.io/source-tlsroute` | Route name | **(TLSRoute only)** Source TLSRoute name |
+| `bindy.firestoned.io/source-name` | Route name | Source route name |
 | `bindy.firestoned.io/zone` | Zone name | Allows `DNSZone.spec.recordsFrom` label selectors to discover the record |
 
 This allows you to configure a `DNSZone` to pull in all ARecords created by Scout from both Ingress and Gateway API routes:

--- a/docs/src/installation/scout.md
+++ b/docs/src/installation/scout.md
@@ -283,17 +283,8 @@ Within seconds, Scout creates an `ARecord` in `bindy-system`:
 # All Scout-managed records
 kubectl get arecords -n bindy-system -l bindy.firestoned.io/managed-by=scout
 
-# Ingress-sourced only
-kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-ingress
-
-# Service-sourced only
-kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-service
-
-# HTTPRoute-sourced only
-kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-httproute
-
-# TLSRoute-sourced only
-kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-tlsroute
+# Records from a specific source resource (works for any kind: Ingress, Service, HTTPRoute, TLSRoute)
+kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-name=<resource-name>
 ```
 
 ---

--- a/examples/httproute-dns.yaml
+++ b/examples/httproute-dns.yaml
@@ -16,7 +16,7 @@
 #   kubectl apply -f examples/httproute-dns.yaml
 #
 # Verify Scout created the ARecords:
-#   kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-httproute=api-gateway
+#   kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-name=api-gateway
 #
 # Verify DNS resolution:
 #   kubectl run -it --rm drill --image=alpine/drill:latest -- drill @<dns-server> api.example.com

--- a/examples/tlsroute-dns.yaml
+++ b/examples/tlsroute-dns.yaml
@@ -18,7 +18,7 @@
 #   kubectl apply -f examples/tlsroute-dns.yaml
 #
 # Verify Scout created the ARecords:
-#   kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-tlsroute=secure-gateway
+#   kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-name=secure-gateway
 #
 # Verify DNS resolution:
 #   kubectl run -it --rm drill --image=alpine/drill:latest -- drill @<dns-server> secure.example.com

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -172,17 +172,9 @@ pub const LABEL_SOURCE_CLUSTER: &str = "bindy.firestoned.io/source-cluster";
 /// Label identifying the source namespace on created ARecords
 pub const LABEL_SOURCE_NAMESPACE: &str = "bindy.firestoned.io/source-namespace";
 
-/// Label identifying the source Ingress name on created ARecords
-pub const LABEL_SOURCE_INGRESS: &str = "bindy.firestoned.io/source-ingress";
-
-/// Label identifying the source Service name on created ARecords
-pub const LABEL_SOURCE_SERVICE: &str = "bindy.firestoned.io/source-service";
-
-/// Label identifying the source HTTPRoute name on created ARecords
-pub const LABEL_SOURCE_HTTPROUTE: &str = "bindy.firestoned.io/source-httproute";
-
-/// Label identifying the source TLSRoute name on created ARecords
-pub const LABEL_SOURCE_TLSROUTE: &str = "bindy.firestoned.io/source-tlsroute";
+/// Label identifying the source resource name on created ARecords.
+/// Used for all resource kinds (Ingress, Service, HTTPRoute, TLSRoute).
+pub const LABEL_SOURCE_NAME: &str = "bindy.firestoned.io/source-name";
 
 /// Label carrying the DNS zone name on created ARecords (for DNSZone selector matching)
 pub const LABEL_ZONE: &str = "bindy.firestoned.io/zone";
@@ -448,15 +440,15 @@ pub fn is_being_deleted(ingress: &Ingress) -> bool {
 /// by Scout for a specific Ingress.
 ///
 /// Selects on `managed-by=scout`, `source-cluster`, `source-namespace`, and
-/// `source-ingress` to precisely target only the records owned by this Ingress.
+/// `source-name` to precisely target only the records owned by this Ingress.
 pub fn arecord_label_selector(cluster: &str, namespace: &str, ingress_name: &str) -> String {
     format!(
-        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{ingress_key}={ingress_name}",
+        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{name_key}={ingress_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        ingress_key = LABEL_SOURCE_INGRESS,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -472,12 +464,12 @@ pub fn stale_arecord_label_selector(
     ingress_name: &str,
 ) -> String {
     format!(
-        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{ingress_key}={ingress_name}",
+        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{name_key}={ingress_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        ingress_key = LABEL_SOURCE_INGRESS,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -523,7 +515,7 @@ pub fn build_arecord(params: ARecordParams<'_>) -> ARecord {
         params.ingress_namespace.to_string(),
     );
     labels.insert(
-        LABEL_SOURCE_INGRESS.to_string(),
+        LABEL_SOURCE_NAME.to_string(),
         params.ingress_name.to_string(),
     );
     labels.insert(LABEL_ZONE.to_string(), params.zone.to_string());
@@ -598,12 +590,12 @@ pub fn service_arecord_label_selector(
     service_name: &str,
 ) -> String {
     format!(
-        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{svc_key}={service_name}",
+        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{name_key}={service_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        svc_key = LABEL_SOURCE_SERVICE,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -645,7 +637,7 @@ pub fn build_service_arecord(params: ServiceARecordParams<'_>) -> ARecord {
         params.service_namespace.to_string(),
     );
     labels.insert(
-        LABEL_SOURCE_SERVICE.to_string(),
+        LABEL_SOURCE_NAME.to_string(),
         params.service_name.to_string(),
     );
     labels.insert(LABEL_ZONE.to_string(), params.zone.to_string());
@@ -715,12 +707,12 @@ pub fn httproute_arecord_label_selector(
     route_name: &str,
 ) -> String {
     format!(
-        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{route_key}={route_name}",
+        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{name_key}={route_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        route_key = LABEL_SOURCE_HTTPROUTE,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -728,12 +720,12 @@ pub fn httproute_arecord_label_selector(
 /// for a specific TLSRoute.
 pub fn tlsroute_arecord_label_selector(cluster: &str, namespace: &str, route_name: &str) -> String {
     format!(
-        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{route_key}={route_name}",
+        "{}={},{cluster_key}={cluster},{ns_key}={namespace},{name_key}={route_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        route_key = LABEL_SOURCE_TLSROUTE,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -748,12 +740,12 @@ pub fn stale_httproute_arecord_label_selector(
     route_name: &str,
 ) -> String {
     format!(
-        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{route_key}={route_name}",
+        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{name_key}={route_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        route_key = LABEL_SOURCE_HTTPROUTE,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -765,12 +757,12 @@ pub fn stale_tlsroute_arecord_label_selector(
     route_name: &str,
 ) -> String {
     format!(
-        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{route_key}={route_name}",
+        "{}={},{cluster_key}!={current_cluster},{ns_key}={namespace},{name_key}={route_name}",
         LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT,
         cluster_key = LABEL_SOURCE_CLUSTER,
         ns_key = LABEL_SOURCE_NAMESPACE,
-        route_key = LABEL_SOURCE_TLSROUTE,
+        name_key = LABEL_SOURCE_NAME,
     )
 }
 
@@ -811,10 +803,7 @@ pub fn build_httproute_arecord(params: HTTPRouteARecordParams<'_>) -> ARecord {
         LABEL_SOURCE_NAMESPACE.to_string(),
         params.route_namespace.to_string(),
     );
-    labels.insert(
-        LABEL_SOURCE_HTTPROUTE.to_string(),
-        params.route_name.to_string(),
-    );
+    labels.insert(LABEL_SOURCE_NAME.to_string(), params.route_name.to_string());
     labels.insert(LABEL_ZONE.to_string(), params.zone.to_string());
 
     let meta = kube::api::ObjectMeta {
@@ -872,10 +861,7 @@ pub fn build_tlsroute_arecord(params: TLSRouteARecordParams<'_>) -> ARecord {
         LABEL_SOURCE_NAMESPACE.to_string(),
         params.route_namespace.to_string(),
     );
-    labels.insert(
-        LABEL_SOURCE_TLSROUTE.to_string(),
-        params.route_name.to_string(),
-    );
+    labels.insert(LABEL_SOURCE_NAME.to_string(), params.route_name.to_string());
     labels.insert(LABEL_ZONE.to_string(), params.zone.to_string());
 
     let meta = kube::api::ObjectMeta {

--- a/src/scout_tests.rs
+++ b/src/scout_tests.rs
@@ -12,7 +12,7 @@ mod tests {
         resolve_ip_from_service_lb_status, resolve_ips, resolve_zone, service_arecord_cr_name,
         service_arecord_label_selector, stale_arecord_label_selector, ServiceARecordParams,
         FINALIZER_SCOUT, LABEL_MANAGED_BY, LABEL_MANAGED_BY_SCOUT, LABEL_SOURCE_CLUSTER,
-        LABEL_SOURCE_INGRESS, LABEL_SOURCE_NAMESPACE, LABEL_SOURCE_SERVICE, LABEL_ZONE,
+        LABEL_SOURCE_NAME, LABEL_SOURCE_NAMESPACE, LABEL_ZONE,
     };
     use k8s_openapi::api::core::v1::{
         LoadBalancerIngress as ServiceLoadBalancerIngress, LoadBalancerStatus, Service,
@@ -388,7 +388,7 @@ mod tests {
                 LABEL_MANAGED_BY_SCOUT,
                 LABEL_SOURCE_CLUSTER,
                 LABEL_SOURCE_NAMESPACE,
-                LABEL_SOURCE_INGRESS,
+                LABEL_SOURCE_NAME,
             )
         );
     }
@@ -399,7 +399,7 @@ mod tests {
         assert!(selector.contains(LABEL_MANAGED_BY));
         assert!(selector.contains(LABEL_SOURCE_CLUSTER));
         assert!(selector.contains(LABEL_SOURCE_NAMESPACE));
-        assert!(selector.contains(LABEL_SOURCE_INGRESS));
+        assert!(selector.contains(LABEL_SOURCE_NAME));
     }
 
     // =========================================================================
@@ -430,7 +430,7 @@ mod tests {
     fn test_stale_arecord_label_selector_contains_namespace_and_ingress() {
         let selector = stale_arecord_label_selector("new-cluster", "my-ns", "my-ingress");
         assert!(selector.contains(&format!("{}=my-ns", LABEL_SOURCE_NAMESPACE)));
-        assert!(selector.contains(&format!("{}=my-ingress", LABEL_SOURCE_INGRESS)));
+        assert!(selector.contains(&format!("{}=my-ingress", LABEL_SOURCE_NAME)));
     }
 
     #[test]
@@ -706,7 +706,7 @@ mod tests {
                 LABEL_MANAGED_BY_SCOUT,
                 LABEL_SOURCE_CLUSTER,
                 LABEL_SOURCE_NAMESPACE,
-                LABEL_SOURCE_SERVICE,
+                LABEL_SOURCE_NAME,
             )
         );
     }
@@ -717,9 +717,7 @@ mod tests {
         assert!(selector.contains(LABEL_MANAGED_BY));
         assert!(selector.contains(LABEL_SOURCE_CLUSTER));
         assert!(selector.contains(LABEL_SOURCE_NAMESPACE));
-        assert!(selector.contains(LABEL_SOURCE_SERVICE));
-        // Must NOT use the Ingress label
-        assert!(!selector.contains(LABEL_SOURCE_INGRESS));
+        assert!(selector.contains(LABEL_SOURCE_NAME));
     }
 
     // =========================================================================
@@ -742,11 +740,9 @@ mod tests {
 
         let labels = arecord.metadata.labels.as_ref().unwrap();
         assert_eq!(
-            labels.get(LABEL_SOURCE_SERVICE).map(String::as_str),
+            labels.get(LABEL_SOURCE_NAME).map(String::as_str),
             Some("my-svc")
         );
-        // Must NOT set the Ingress label
-        assert!(!labels.contains_key(LABEL_SOURCE_INGRESS));
     }
 
     #[test]
@@ -777,7 +773,7 @@ mod tests {
             Some("default")
         );
         assert_eq!(
-            labels.get(LABEL_SOURCE_SERVICE).map(String::as_str),
+            labels.get(LABEL_SOURCE_NAME).map(String::as_str),
             Some("my-svc")
         );
         assert_eq!(
@@ -892,8 +888,7 @@ mod tests {
         assert!(selector.contains("prod"));
         assert!(selector.contains("default"));
         assert!(selector.contains("api-route"));
-        // Verify it has the source-httproute label (different from source-ingress)
-        assert!(selector.contains("source-httproute"));
+        assert!(selector.contains("source-name"));
     }
 
     #[test]
@@ -908,20 +903,20 @@ mod tests {
         assert!(selector.contains("prod"));
         assert!(selector.contains("default"));
         assert!(selector.contains("secure-route"));
-        // Verify it has the source-tlsroute label
-        assert!(selector.contains("source-tlsroute"));
+        assert!(selector.contains("source-name"));
     }
 
     #[test]
-    fn test_httproute_arecord_label_selector_distinct_from_tlsroute() {
+    fn test_httproute_and_tlsroute_selectors_share_source_name_label() {
         // Arrange & Act
         let http_selector =
             crate::scout::httproute_arecord_label_selector("prod", "default", "route");
         let tls_selector =
             crate::scout::tlsroute_arecord_label_selector("prod", "default", "route");
 
-        // Assert — they must differ because they target different route types
-        assert_ne!(http_selector, tls_selector);
+        // Both use the unified source-name label — selectors are structurally identical
+        assert_eq!(http_selector, tls_selector);
+        assert!(http_selector.contains("source-name=route"));
     }
 
     #[test]
@@ -935,9 +930,8 @@ mod tests {
 
         // Assert
         assert!(selector.contains(&format!("{}!=new-cluster", LABEL_SOURCE_CLUSTER)));
-        assert!(selector.contains("source-httproute"));
+        assert!(selector.contains("source-name=api-route"));
         assert!(selector.contains("default"));
-        assert!(selector.contains("api-route"));
     }
 
     #[test]
@@ -951,9 +945,8 @@ mod tests {
 
         // Assert
         assert!(selector.contains(&format!("{}!=new-cluster", LABEL_SOURCE_CLUSTER)));
-        assert!(selector.contains("source-tlsroute"));
+        assert!(selector.contains("source-name=secure-route"));
         assert!(selector.contains("default"));
-        assert!(selector.contains("secure-route"));
     }
 
     #[test]
@@ -988,11 +981,8 @@ mod tests {
             labels.get(LABEL_SOURCE_NAMESPACE).map(String::as_str),
             Some("default")
         );
-        // Must use "source-httproute" label, not "source-ingress"
         assert_eq!(
-            labels
-                .get("bindy.firestoned.io/source-httproute")
-                .map(String::as_str),
+            labels.get(LABEL_SOURCE_NAME).map(String::as_str),
             Some("api-route")
         );
         assert_eq!(
@@ -1053,11 +1043,8 @@ mod tests {
             labels.get(LABEL_SOURCE_CLUSTER).map(String::as_str),
             Some("prod")
         );
-        // Must use "source-tlsroute" label
         assert_eq!(
-            labels
-                .get("bindy.firestoned.io/source-tlsroute")
-                .map(String::as_str),
+            labels.get(LABEL_SOURCE_NAME).map(String::as_str),
             Some("secure-route")
         );
         assert_eq!(


### PR DESCRIPTION
Change the scout source label to be ubiquitous across the different "kinds", just source-name