### PR TITLE
version command

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -1,3 +1,41 @@
+## [2026-07-18] - Add `version` subcommand and `--version`/`-V` flag to the bindy CLI
+
+**Author:** Daniel Guns
+
+### Added
+- `src/main.rs`: `version` attribute on the clap `Cli` struct — `bindy --version`
+  and `bindy -V` now print the binary version, sourced automatically from
+  `Cargo.toml`'s `version` via `CARGO_PKG_VERSION` at compile time (same source
+  `bootstrap::DEFAULT_IMAGE_TAG` already uses), so it can never drift from the
+  crate version.
+- `src/main.rs`: `Commands::Version` subcommand — `bindy version` prints the
+  identical output (via `Cli::command().render_version()`), handled synchronously
+  before the Tokio runtime is built, same pattern as `completion`.
+- `src/main_tests.rs`: TDD tests asserting the CLI version matches
+  `CARGO_PKG_VERSION`, that `--version`/`-V` short-circuit with
+  `ErrorKind::DisplayVersion`, that `bindy version` parses to
+  `Commands::Version`, and that the rendered output is exactly
+  `bindy <CARGO_PKG_VERSION>`.
+- `docs/src/reference/cli.md`: documented the new subcommand and flag.
+
+### Why
+`./bindy --version` and `./bindy version` both errored — the binary had no way
+to report its own version, which is the first step when troubleshooting which
+CLI version is deployed. The clap built-in flag plus a thin subcommand wrapper
+is the idiomatic, zero-maintenance fix; shell completions pick both up
+automatically since they are generated from the same `Cli` definition.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only (CLI surface addition; no runtime behavior change)
+
+### Verification
+- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo test` all green (1217 lib + 16 bin + 47 doc tests).
+- End-to-end: `./target/debug/bindy version`, `--version`, and `-V` all print `bindy 0.6.0`.
+
+---
+
 ## [2026-07-16] - Fix rustdoc private_intra_doc_links warnings
 
 **Author:** Erick Bourgeois

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -10,6 +10,10 @@ Subcommands:
   run         Run the main BIND9 DNS operator (all controllers)
   scout       Run the Scout controller (Ingress and Service → ARecord)
   completion  Output shell completion code for the specified shell
+  version     Print the binary version (same output as --version)
+
+Options:
+  -V, --version  Print the binary version (matches the crate version, e.g. `bindy 0.6.0`)
 ```
 
 ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ const BANNER: &str = "
 #[command(
     name = "bindy",
     about = "Bindy - BIND9 DNS Operator for Kubernetes",
+    version,
     before_help = BANNER,
 )]
 struct Cli {
@@ -223,6 +224,8 @@ enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
+    /// Print the binary version (same output as --version)
+    Version,
 }
 
 fn main() -> Result<()> {
@@ -241,6 +244,13 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Version output is synchronous — no Tokio runtime needed.
+    // render_version() derives from CARGO_PKG_VERSION, matching --version exactly.
+    if let Commands::Version = cli.command {
+        print!("{}", Cli::command().render_version());
+        return Ok(());
+    }
+
     let thread_name = match &cli.command {
         Commands::Bootstrap {
             subcommand: BootstrapCommands::Operator { .. },
@@ -253,7 +263,7 @@ fn main() -> Result<()> {
         } => "bindy-bootstrap-mc",
         Commands::Run => "bindy-run",
         Commands::Scout { .. } => "bindy-scout",
-        Commands::Completion { .. } => unreachable!("handled above"),
+        Commands::Completion { .. } | Commands::Version => unreachable!("handled above"),
     };
 
     // Build Tokio runtime with custom thread names
@@ -327,7 +337,7 @@ fn main() -> Result<()> {
             gateway_service,
             default_zone,
         )),
-        Commands::Completion { .. } => unreachable!("handled above"),
+        Commands::Completion { .. } | Commands::Version => unreachable!("handled above"),
     }
 }
 

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -295,6 +295,79 @@ mod tests {
             "Burst should be >= QPS for proper throttling"
         );
     }
+
+    /// Test that the CLI advertises a version derived from Cargo.toml
+    #[test]
+    fn test_cli_version_matches_cargo_pkg_version() {
+        use clap::CommandFactory;
+
+        let command = super::super::Cli::command();
+        assert_eq!(
+            command.get_version(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "CLI version must be sourced from CARGO_PKG_VERSION"
+        );
+    }
+
+    /// Test that `bindy --version` is accepted and triggers version display
+    #[test]
+    fn test_version_long_flag_displays_version() {
+        use clap::error::ErrorKind;
+        use clap::Parser;
+
+        let result = super::super::Cli::try_parse_from(["bindy", "--version"]);
+        let Err(error) = result else {
+            panic!("--version should short-circuit parsing");
+        };
+        assert_eq!(
+            error.kind(),
+            ErrorKind::DisplayVersion,
+            "--version must display the version"
+        );
+    }
+
+    /// Test that `bindy version` parses as the Version subcommand
+    #[test]
+    fn test_version_subcommand_parses() {
+        use clap::Parser;
+
+        let cli = super::super::Cli::try_parse_from(["bindy", "version"])
+            .unwrap_or_else(|error| panic!("version subcommand should parse: {error}"));
+        assert!(
+            matches!(cli.command, super::super::Commands::Version),
+            "expected Commands::Version"
+        );
+    }
+
+    /// Test that the rendered version output matches the crate version exactly
+    #[test]
+    fn test_rendered_version_matches_cargo_pkg_version() {
+        use clap::CommandFactory;
+
+        let rendered = super::super::Cli::command().render_version();
+        assert_eq!(
+            rendered.trim(),
+            concat!("bindy ", env!("CARGO_PKG_VERSION")),
+            "rendered version must be 'bindy <CARGO_PKG_VERSION>'"
+        );
+    }
+
+    /// Test that the short `-V` version flag is accepted
+    #[test]
+    fn test_version_short_flag_displays_version() {
+        use clap::error::ErrorKind;
+        use clap::Parser;
+
+        let result = super::super::Cli::try_parse_from(["bindy", "-V"]);
+        let Err(error) = result else {
+            panic!("-V should short-circuit parsing");
+        };
+        assert_eq!(
+            error.kind(),
+            ErrorKind::DisplayVersion,
+            "-V must display the version"
+        );
+    }
 }
 
 // Integration test documentation


### PR DESCRIPTION
## Add `version` subcommand and `--version` / `-V` flag to the bindy CLI

### Why

There was no way to check which version of the CLI you're running — `bindy --version` and `bindy version` both errored. When troubleshooting a cluster, knowing the exact binary version is the first debugging step (e.g. confirming the CLI matches the deployed operator image).

### Changes

- **`src/main.rs`** — added clap's built-in `version` attribute to the `Cli` struct (`--version` / `-V`), plus a `version` subcommand that prints the identical output via `Cli::command().render_version()`. The version is sourced at compile time from `Cargo.toml` via `CARGO_PKG_VERSION` — the same source `bootstrap::DEFAULT_IMAGE_TAG` uses — so it can never drift from the crate version and needs no maintenance on release bumps. The subcommand runs synchronously before the Tokio runtime is built, same pattern as `completion`.
- **`src/main_tests.rs`** — tests (written first, TDD) covering: CLI version matches `CARGO_PKG_VERSION`, `--version`/`-V` trigger version display, `bindy version` parses to the Version subcommand, and rendered output is exactly `bindy <version>`.
- **`docs/src/reference/cli.md`** — documented the subcommand and flag.
- **`.claude/CHANGELOG.md`** — changelog entry.

```console
$ bindy version
bindy 0.6.0
$ bindy --version
bindy 0.6.0
```

Shell completions pick both up automatically since they're generated from the same `Cli` definition.

### Verification

`cargo fmt` / `clippy -D warnings` / full test suite green (1217 lib + 16 bin + 47 doc tests); `make docs` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)