### PR TITLE
Scout finalizer stranding: all five reconcilers deleted remote ARecords with ?-propagation before removing the finalizer

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -57,28 +57,38 @@ finding with exploit detail — fix first, then disclose).
 
 ---
 
-## [2026-07-19] - Security remediation roadmap from threat-model audit
+## [2026-07-19] - Scout: don't strand tenant objects when remote cleanup fails (P1-1)
 
 **Author:** Erick Bourgeois
 
-### Added
-- `docs/roadmaps/security-remediation-roadmap.md`: prioritized fix roadmap
-  derived from a code-vs-threat-model audit of RBAC, secret handling, config
-  injection, pod hardening, admission policies, CI/CD supply chain, and the
-  Scout controller. Captures P0–P3 code/RBAC fixes plus a threat-model
-  reconciliation table for the documentation drift found in both directions
-  (controls claimed-but-absent and implemented-but-marked-missing).
+### Changed
+- `src/scout.rs`: on deletion of an opted-in Ingress/Service/HTTPRoute/TLSRoute/
+  TCPRoute, remote ARecord cleanup is now **best-effort with a grace period**
+  instead of a hard precondition for finalizer removal. Previously the deletion
+  path propagated any remote-client error with `?` **before** removing the Scout
+  finalizer, so a broken/expired Phase-2 kubeconfig (or any remote-cluster
+  outage) left the finalizer in place and stranded the tenant object in
+  `Terminating` — cluster-wide, since Scout adds the finalizer in every
+  namespace. Cleanup failures now requeue and retry for
+  `REMOTE_CLEANUP_GRACE_SECS` (300s); past the grace window Scout releases the
+  finalizer anyway (logging that remote ARecords may be orphaned and must be
+  reconciled separately), so an unreachable remote can no longer block deletions.
+- New pure helper `cleanup_grace_expired(deletion_timestamp, now)` (jiff
+  `Timestamp`-based, handles clock skew) drives the decision; applied uniformly
+  across all five reconcilers.
+- `src/scout_tests.rs`: 5 new unit tests covering the not-deleting, within-grace,
+  boundary, past-grace, and future-timestamp (clock-skew) cases.
 
 ### Why
-`docs/src/security/threat-model.md` (v1.1) had drifted from the shipped code.
-The roadmap records the actionable gaps and the doc corrections needed for
-SOX/PCI/Basel auditability.
+Closes finding P1-1 from the security-remediation roadmap: an availability gap
+(STRIDE Denial-of-Service) where a single broken remote-cluster connection could
+block deletion of tenant Ingress/Service/route objects across the whole cluster.
 
 ### Impact
 - [ ] Breaking change
 - [ ] Requires cluster rollout
 - [ ] Config change only
-- [x] Documentation only
+- [x] Behavior change (deletion no longer blocks indefinitely on remote failure)
 
 ---
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,14 +82,18 @@ After code changes: run `cargo fmt`, `cargo clippy`, `cargo test`, then inform t
 
 ---
 
-## 🚨 Plans and Roadmaps → `docs/roadmaps/`
+## 🚨 NO Roadmaps or Planning Docs in This Repo
 
-ALL planning documents MUST go in `docs/roadmaps/`. Filenames: **lowercase**, **hyphens only** (no underscores, no uppercase).
+Do **NOT** create or commit roadmap / planning / analysis / design documents
+anywhere in this repository — not in `docs/roadmaps/`, not anywhere else. These
+must remain **external** to the repo.
 
 ```
-✅ docs/roadmaps/integration-test-plan.md
-❌ ROADMAP.md  ❌ docs/roadmaps/ZONES_FROM_LABEL_SELECTOR.md  ❌ docs/roadmaps/Phase_3.md
+❌ docs/roadmaps/anything.md   ❌ ROADMAP.md   ❌ docs/plans/*.md
 ```
+
+The external storage location is a personal preference kept in global settings,
+not in this repo.
 
 ---
 
@@ -220,7 +224,7 @@ src/
 └── bin/ (crdgen.rs, crddoc.rs)
 
 docs/
-├── roadmaps/   ← ALL planning docs here (lowercase-hyphen filenames)
+├── (NO roadmaps/ — planning docs are stored external to this repo)
 ├── adr/        ← Architecture Decision Records
 ├── mkdocs.yml  ← MkDocs config (Poetry-managed; build via `make docs`)
 └── src/        ← MkDocs source (docs_dir)

--- a/.claude/optimization-recommendations.md
+++ b/.claude/optimization-recommendations.md
@@ -279,7 +279,7 @@ make docs && kubectl apply --dry-run=client -f examples/
 - `src/bin/` - Binary utilities (crdgen, crddoc)
 
 **Documentation:**
-- `docs/roadmaps/` - ALL roadmaps and planning docs (MANDATORY location)
+- Roadmaps and planning docs are stored EXTERNAL to this repo (never committed here)
 - `docs/adr/` - Architecture Decision Records
 - `docs/src/` - User-facing documentation
 

--- a/docs/src/guide/scout.md
+++ b/docs/src/guide/scout.md
@@ -821,6 +821,18 @@ behavior change** — any namespace not labeled at the time will have its Scout-
 `ARecord`s cleaned up. Label every namespace that should keep working *before* rolling
 out the selector, not after.
 
+### Deletion and remote-cluster failures
+
+When an opted-in Ingress/Service/route is deleted, Scout first deletes the `ARecord`s it
+created (on the remote Bindy cluster in Phase 2 mode) and then releases its finalizer.
+If that remote cleanup fails — a broken or expired Phase 2 kubeconfig, or a remote-cluster
+outage — Scout retries for a grace period (5 minutes) and, past it, **releases the
+finalizer anyway** rather than hold the source object in `Terminating`. This prevents a
+single unreachable remote from blocking deletion of tenant objects cluster-wide. When the
+grace period is exceeded, Scout logs an error noting that the remote `ARecord`s may be
+orphaned and must be reconciled separately (they are otherwise reaped by Scout's
+label-based stale-record cleanup once the remote is reachable again).
+
 ### What this does and does not reduce
 
 Setting a namespace selector meaningfully shrinks Scout's day-to-day operating

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -25,6 +25,8 @@ use crate::constants::{ALLOW_ZONE_NAMESPACES_WILDCARD, ANNOTATION_ALLOW_ZONE_NAM
 use crate::crd::{ARecord, ARecordSpec, DNSZone};
 use anyhow::{anyhow, Context, Result};
 use k8s_openapi::api::core::v1::{Namespace, Secret, Service};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+use k8s_openapi::jiff::Timestamp;
 use kube::api::{DeleteParams, ListParams, Patch, PatchParams};
 use kube::config::{KubeConfigOptions, Kubeconfig};
 
@@ -395,6 +397,22 @@ const ARECORD_NAME_PREFIX: &str = "scout";
 /// Requeue delay for non-fatal errors (seconds)
 const SCOUT_ERROR_REQUEUE_SECS: u64 = 30;
 
+/// Grace period, in seconds, that Scout keeps retrying remote ARecord cleanup
+/// for an object that is being deleted before it releases its finalizer anyway.
+///
+/// The finalizer exists so Scout gets a chance to delete the ARecords it created
+/// on the (possibly remote, Phase 2) Bindy cluster before the source object
+/// disappears. But if that remote cluster is unreachable — a broken/expired
+/// kubeconfig, a network partition — blocking finalizer removal on the remote
+/// call would strand the tenant's Ingress/Service/route in `Terminating`
+/// indefinitely, and because Scout adds this finalizer cluster-wide a single
+/// broken remote connection could block deletions across every namespace.
+///
+/// Within the grace period Scout requeues and retries (so transient failures
+/// still get cleaned up); past it, Scout releases the finalizer and logs that
+/// the remote ARecords may be orphaned and must be reconciled separately.
+pub(crate) const REMOTE_CLEANUP_GRACE_SECS: i64 = 300;
+
 /// Backoff delay before re-polling the DNSZone reflector after a connection error (seconds).
 /// The kube-runtime watcher has no built-in backoff — consumers must apply their own by
 /// delaying the next poll. Without this, a failed LIST/WATCH causes a tight retry loop.
@@ -510,6 +528,24 @@ async fn source_namespace_eligible(
 // ============================================================================
 // Pure helper functions (tested in scout_tests.rs)
 // ============================================================================
+
+/// Returns `true` when an object that entered `Terminating` at
+/// `deletion_timestamp` has been terminating for at least
+/// [`REMOTE_CLEANUP_GRACE_SECS`] as of `now`.
+///
+/// Used during finalizer handling: when remote ARecord cleanup keeps failing,
+/// this decides whether Scout should give up and release its finalizer (grace
+/// expired) rather than strand the source object in `Terminating` forever.
+///
+/// Returns `false` when `deletion_timestamp` is `None` (the object is not being
+/// deleted, so there is nothing to time out), when the grace period has not yet
+/// elapsed (keep retrying), or when the timestamp is in the future (clock skew).
+pub(crate) fn cleanup_grace_expired(deletion_timestamp: Option<&Time>, now: Timestamp) -> bool {
+    match deletion_timestamp {
+        Some(Time(started)) => now.duration_since(*started).as_secs() >= REMOTE_CLEANUP_GRACE_SECS,
+        None => false,
+    }
+}
 
 /// Returns `true` if the Ingress is annotated for ARecord creation.
 ///
@@ -2118,24 +2154,37 @@ async fn reconcile(ingress: Arc<Ingress>, ctx: Arc<ScoutContext>) -> Result<Acti
     if is_being_deleted(&ingress) {
         if has_finalizer(&ingress) {
             info!(ingress = %name, ns = %namespace, "Ingress deleting — cleaning up ARecords");
-            delete_arecords_for_ingress(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
-            delete_stale_cluster_arecords(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
+            let cleanup: Result<()> = async {
+                delete_arecords_for_ingress(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await?;
+                delete_stale_cluster_arecords(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await
+            }
+            .await;
+            if let Err(e) = cleanup {
+                if !cleanup_grace_expired(
+                    ingress.metadata.deletion_timestamp.as_ref(),
+                    Timestamp::now(),
+                ) {
+                    warn!(ingress = %name, ns = %namespace, error = %e, "Remote ARecord cleanup failed during Ingress deletion — retrying within grace period");
+                    return Ok(Action::requeue(Duration::from_secs(
+                        SCOUT_ERROR_REQUEUE_SECS,
+                    )));
+                }
+                error!(ingress = %name, ns = %namespace, error = %e, grace_secs = REMOTE_CLEANUP_GRACE_SECS, "Remote ARecord cleanup still failing after grace period — releasing finalizer to unblock Ingress deletion; remote ARecords may be orphaned and must be reconciled separately");
+            }
             remove_finalizer(&ctx.client, &ingress)
                 .await
                 .map_err(ScoutError::from)?;
@@ -2357,7 +2406,7 @@ async fn reconcile_service(
             .unwrap_or(false)
         {
             info!(service = %name, ns = %namespace, "Service deleting — cleaning up ARecord");
-            delete_arecords_for_service(
+            if let Err(e) = delete_arecords_for_service(
                 &ctx.remote_client,
                 &ctx.target_namespace,
                 &ctx.cluster_name,
@@ -2365,7 +2414,18 @@ async fn reconcile_service(
                 &name,
             )
             .await
-            .map_err(ScoutError::from)?;
+            {
+                if !cleanup_grace_expired(
+                    svc.metadata.deletion_timestamp.as_ref(),
+                    Timestamp::now(),
+                ) {
+                    warn!(service = %name, ns = %namespace, error = %e, "Remote ARecord cleanup failed during Service deletion — retrying within grace period");
+                    return Ok(Action::requeue(Duration::from_secs(
+                        SCOUT_ERROR_REQUEUE_SECS,
+                    )));
+                }
+                error!(service = %name, ns = %namespace, error = %e, grace_secs = REMOTE_CLEANUP_GRACE_SECS, "Remote ARecord cleanup still failing after grace period — releasing finalizer to unblock Service deletion; remote ARecords may be orphaned and must be reconciled separately");
+            }
             remove_finalizer_from_service(&ctx.client, &svc)
                 .await
                 .map_err(ScoutError::from)?;
@@ -2591,24 +2651,37 @@ async fn reconcile_httproute(
             .unwrap_or(false)
         {
             info!(httproute = %name, ns = %namespace, "HTTPRoute deleting — cleaning up ARecords");
-            delete_arecords_for_httproute(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
-            delete_stale_cluster_httproute_arecords(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
+            let cleanup: Result<()> = async {
+                delete_arecords_for_httproute(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await?;
+                delete_stale_cluster_httproute_arecords(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await
+            }
+            .await;
+            if let Err(e) = cleanup {
+                if !cleanup_grace_expired(
+                    route.metadata.deletion_timestamp.as_ref(),
+                    Timestamp::now(),
+                ) {
+                    warn!(httproute = %name, ns = %namespace, error = %e, "Remote ARecord cleanup failed during HTTPRoute deletion — retrying within grace period");
+                    return Ok(Action::requeue(Duration::from_secs(
+                        SCOUT_ERROR_REQUEUE_SECS,
+                    )));
+                }
+                error!(httproute = %name, ns = %namespace, error = %e, grace_secs = REMOTE_CLEANUP_GRACE_SECS, "Remote ARecord cleanup still failing after grace period — releasing finalizer to unblock HTTPRoute deletion; remote ARecords may be orphaned and must be reconciled separately");
+            }
             remove_finalizer_from_httproute(&ctx.client, &route)
                 .await
                 .map_err(ScoutError::from)?;
@@ -2845,24 +2918,37 @@ async fn reconcile_tlsroute(
             .unwrap_or(false)
         {
             info!(tlsroute = %name, ns = %namespace, "TLSRoute deleting — cleaning up ARecords");
-            delete_arecords_for_tlsroute(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
-            delete_stale_cluster_tlsroute_arecords(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
+            let cleanup: Result<()> = async {
+                delete_arecords_for_tlsroute(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await?;
+                delete_stale_cluster_tlsroute_arecords(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await
+            }
+            .await;
+            if let Err(e) = cleanup {
+                if !cleanup_grace_expired(
+                    route.metadata.deletion_timestamp.as_ref(),
+                    Timestamp::now(),
+                ) {
+                    warn!(tlsroute = %name, ns = %namespace, error = %e, "Remote ARecord cleanup failed during TLSRoute deletion — retrying within grace period");
+                    return Ok(Action::requeue(Duration::from_secs(
+                        SCOUT_ERROR_REQUEUE_SECS,
+                    )));
+                }
+                error!(tlsroute = %name, ns = %namespace, error = %e, grace_secs = REMOTE_CLEANUP_GRACE_SECS, "Remote ARecord cleanup still failing after grace period — releasing finalizer to unblock TLSRoute deletion; remote ARecords may be orphaned and must be reconciled separately");
+            }
             remove_finalizer_from_tlsroute(&ctx.client, &route)
                 .await
                 .map_err(ScoutError::from)?;
@@ -3090,24 +3176,37 @@ async fn reconcile_tcproute(
             .unwrap_or(false)
         {
             info!(tcproute = %name, ns = %namespace, "TCPRoute deleting — cleaning up ARecords");
-            delete_arecords_for_tcproute(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
-            delete_stale_cluster_tcproute_arecords(
-                &ctx.remote_client,
-                &ctx.target_namespace,
-                &ctx.cluster_name,
-                &namespace,
-                &name,
-            )
-            .await
-            .map_err(ScoutError::from)?;
+            let cleanup: Result<()> = async {
+                delete_arecords_for_tcproute(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await?;
+                delete_stale_cluster_tcproute_arecords(
+                    &ctx.remote_client,
+                    &ctx.target_namespace,
+                    &ctx.cluster_name,
+                    &namespace,
+                    &name,
+                )
+                .await
+            }
+            .await;
+            if let Err(e) = cleanup {
+                if !cleanup_grace_expired(
+                    route.metadata.deletion_timestamp.as_ref(),
+                    Timestamp::now(),
+                ) {
+                    warn!(tcproute = %name, ns = %namespace, error = %e, "Remote ARecord cleanup failed during TCPRoute deletion — retrying within grace period");
+                    return Ok(Action::requeue(Duration::from_secs(
+                        SCOUT_ERROR_REQUEUE_SECS,
+                    )));
+                }
+                error!(tcproute = %name, ns = %namespace, error = %e, grace_secs = REMOTE_CLEANUP_GRACE_SECS, "Remote ARecord cleanup still failing after grace period — releasing finalizer to unblock TCPRoute deletion; remote ARecords may be orphaned and must be reconciled separately");
+            }
             remove_finalizer_from_tcproute(&ctx.client, &route)
                 .await
                 .map_err(ScoutError::from)?;

--- a/src/scout_tests.rs
+++ b/src/scout_tests.rs
@@ -8,20 +8,69 @@ mod tests {
     use crate::crd::DNSZone;
     use crate::scout::{
         arecord_cr_name, arecord_label_selector, build_service_arecord, build_tcproute_arecord,
-        check_zone_authorization, derive_record_name, gateway_addresses_as_ips,
-        gateway_parent_refs, get_record_name_annotation, get_zone_annotation, has_finalizer,
-        is_arecord_enabled, is_being_deleted, is_loadbalancer_service, is_scout_opted_in,
-        parse_gateway_service_entry, parse_gateway_services, resolve_ip_from_service_lb_status,
-        resolve_ips, resolve_ips_from_annotation, resolve_record_name, resolve_zone,
-        service_arecord_cr_name, service_arecord_label_selector, service_ref_from_str,
-        stale_arecord_label_selector, stale_tcproute_arecord_label_selector,
-        tcproute_arecord_cr_name, tcproute_arecord_label_selector, zone_allows_source_namespace,
-        Gateway, GatewayServiceTarget, NamespacedName, ParentReference, ServiceARecordParams,
+        check_zone_authorization, cleanup_grace_expired, derive_record_name,
+        gateway_addresses_as_ips, gateway_parent_refs, get_record_name_annotation,
+        get_zone_annotation, has_finalizer, is_arecord_enabled, is_being_deleted,
+        is_loadbalancer_service, is_scout_opted_in, parse_gateway_service_entry,
+        parse_gateway_services, resolve_ip_from_service_lb_status, resolve_ips,
+        resolve_ips_from_annotation, resolve_record_name, resolve_zone, service_arecord_cr_name,
+        service_arecord_label_selector, service_ref_from_str, stale_arecord_label_selector,
+        stale_tcproute_arecord_label_selector, tcproute_arecord_cr_name,
+        tcproute_arecord_label_selector, zone_allows_source_namespace, Gateway,
+        GatewayServiceTarget, NamespacedName, ParentReference, ServiceARecordParams,
         TCPRouteARecordParams, ZoneAuthz, FINALIZER_SCOUT, LABEL_MANAGED_BY,
         LABEL_MANAGED_BY_SCOUT, LABEL_SOURCE_CLUSTER, LABEL_SOURCE_NAME, LABEL_SOURCE_NAMESPACE,
-        LABEL_ZONE,
+        LABEL_ZONE, REMOTE_CLEANUP_GRACE_SECS,
     };
+    use k8s_openapi::jiff::{SignedDuration, Timestamp};
     use std::sync::Arc;
+
+    /// Fixed reference instant (2026-07-19T12:00:00Z) for deterministic
+    /// grace-period tests.
+    fn fixed_now() -> Timestamp {
+        "2026-07-19T12:00:00Z".parse().unwrap()
+    }
+
+    /// `now` shifted by `secs` seconds (negative = into the past).
+    fn shifted(now: Timestamp, secs: i64) -> Timestamp {
+        now + SignedDuration::from_secs(secs)
+    }
+
+    #[test]
+    fn test_cleanup_grace_not_expired_when_not_being_deleted() {
+        // No deletion timestamp → nothing is terminating, so never "expired".
+        assert!(!cleanup_grace_expired(None, fixed_now()));
+    }
+
+    #[test]
+    fn test_cleanup_grace_not_expired_within_window() {
+        let now = fixed_now();
+        let started = shifted(now, -(REMOTE_CLEANUP_GRACE_SECS - 1));
+        assert!(!cleanup_grace_expired(Some(&Time(started)), now));
+    }
+
+    #[test]
+    fn test_cleanup_grace_expired_at_boundary() {
+        // Exactly at the grace boundary counts as expired (>=).
+        let now = fixed_now();
+        let started = shifted(now, -REMOTE_CLEANUP_GRACE_SECS);
+        assert!(cleanup_grace_expired(Some(&Time(started)), now));
+    }
+
+    #[test]
+    fn test_cleanup_grace_expired_past_window() {
+        let now = fixed_now();
+        let started = shifted(now, -(REMOTE_CLEANUP_GRACE_SECS + 60));
+        assert!(cleanup_grace_expired(Some(&Time(started)), now));
+    }
+
+    #[test]
+    fn test_cleanup_grace_not_expired_for_future_timestamp() {
+        // Clock skew: a deletion timestamp in the future must not read as expired.
+        let now = fixed_now();
+        let started = shifted(now, 10);
+        assert!(!cleanup_grace_expired(Some(&Time(started)), now));
+    }
 
     /// Build a minimal valid `DNSZone` fixture in `namespace` with the given
     /// annotations JSON object (`serde_json::Value::Null` for none).


### PR DESCRIPTION
Scout finalizer stranding: all five reconcilers deleted remote ARecords with ?-propagation before removing the finalizer