### PR TITLE
Harden DNS defaults: RRL on by default, deny AXFR without an explicit ACL (P1-3, P1-4)

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -25,6 +25,72 @@ pre-existing style/lint issues in the PR's new test code, unrelated to the
 
 ---
 
+## [2026-07-20] - BIND9 Response Rate Limiting, configurable, on by default (P1-3)
+
+**Author:** Erick Bourgeois
+
+### Added
+- `src/crd.rs`: new `RateLimitConfig` struct with `responsesPerSecond: Option<u32>`,
+  exposed as `Bind9Config.rate_limit` (`spec.config.rateLimit` /
+  cluster `spec.global.rateLimit`).
+- `src/bind9_resources.rs`: `build_options_conf` now renders a
+  `rate-limit { responses-per-second N; }` block via `render_rate_limit`.
+  Response Rate Limiting is **on by default** — when `rateLimit` is unset the
+  conservative default `DEFAULT_RATE_LIMIT_RESPONSES_PER_SECOND = 15` is applied
+  (ISC's recommended starting point, per source /24). `responsesPerSecond: 0`
+  disables it (no block emitted). Instance overrides cluster `global`.
+- `templates/named.conf.options.tmpl`: new `{{RATE_LIMIT}}` placeholder.
+- `src/bind9_resources_tests.rs`: 4 tests (default-on, custom value, disabled-with-0,
+  default-when-no-config).
+- Regenerated CRDs (`deploy/operator/crds/*.crd.yaml`) and API docs; documented
+  in `docs/src/reference/bind9instance-spec.md`.
+
+### Why
+Closes finding P1-3 from the security-remediation roadmap. The threat model
+(M-08) claimed BIND9 rate limiting was implemented, but no `rate-limit` directive
+was ever generated — a false assurance against DNS amplification/DDoS (D1/D3).
+This makes M-08 true.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (CRD update + new option in generated config)
+- [ ] Config change only
+- [x] Behavior change (RRL now enforced by default; set `responsesPerSecond: 0` to opt out)
+
+---
+
+## [2026-07-20] - Deny AXFR by default at the options level (P1-4)
+
+**Author:** Erick Bourgeois
+
+### Changed
+- `src/bind9_resources.rs`: `build_options_conf` now emits an explicit
+  `allow-transfer { none; };` (new const `DEFAULT_ALLOW_TRANSFER_NONE`) whenever
+  no transfer ACL is configured at the instance, role, or global level, instead
+  of omitting the directive. An omitted `allow-transfer` inherits BIND9's
+  built-in default of `allow-transfer { any; }`, so a standalone primary zone
+  with no secondaries and no explicit ACL was **open to AXFR from anyone**
+  (bulk zone enumeration — threat model I2; amplification — D3). Zones that need
+  transfers still get a zone-level ACL scoped to their secondary IPs
+  (`bind9::zone_ops`), which overrides this options-level default — replication
+  is unaffected.
+- `src/bind9_resources_tests.rs`: corrected `test_configmap_with_no_config_section`
+  (previously asserted the directive was absent) and added
+  `test_configmap_with_config_but_no_transfer_acl_denies_by_default`.
+
+### Why
+Closes finding P1-4 from the security-remediation roadmap: standalone primaries
+defaulted to AXFR-open, contradicting the model's "AXFR restricted to
+secondaries" posture (M-07).
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [ ] Config change only
+- [x] Behavior change (zones without an explicit transfer ACL now deny AXFR by default)
+
+---
+
 ## [2026-07-19] - Fix M-25: Scout's cluster-wide Secret read scoped to a single namespaced Secret
 
 **Author:** Erick Bourgeois

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# OpenWolf
+
+@.wolf/OPENWOLF.md
+
+This project uses OpenWolf for context management. Read and follow .wolf/OPENWOLF.md every session. Check .wolf/cerebrum.md before generating code. Check .wolf/anatomy.md before reading files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-# OpenWolf
-
-@.wolf/OPENWOLF.md
-
-This project uses OpenWolf for context management. Read and follow .wolf/OPENWOLF.md every session. Check .wolf/cerebrum.md before generating code. Check .wolf/anatomy.md before reading files.
+AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,9 +393,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/deploy/operator/crds/bind9clusters.crd.yaml
+++ b/deploy/operator/crds/bind9clusters.crd.yaml
@@ -816,6 +816,29 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  rateLimit:
+                    description: |-
+                      Response Rate Limiting (RRL) to mitigate DNS amplification/reflection.
+
+                      When unset, a conservative default is applied
+                      (`responses-per-second 15`). Set `responsesPerSecond: 0` to disable RRL
+                      entirely. Instance-level config overrides the cluster `global` value.
+
+                      See `RateLimitConfig`.
+                    nullable: true
+                    properties:
+                      responsesPerSecond:
+                        description: |-
+                          Maximum identical responses per second, per client source prefix.
+
+                          Rendered as BIND9's `rate-limit { responses-per-second N; }`. When unset,
+                          a conservative default of `15` is applied (RRL is on by default). Set to
+                          `0` to disable RRL entirely — no `rate-limit` block is emitted.
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
                   recursion:
                     description: |-
                       Enable or disable recursive DNS queries

--- a/deploy/operator/crds/bind9instances.crd.yaml
+++ b/deploy/operator/crds/bind9instances.crd.yaml
@@ -1074,6 +1074,29 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  rateLimit:
+                    description: |-
+                      Response Rate Limiting (RRL) to mitigate DNS amplification/reflection.
+
+                      When unset, a conservative default is applied
+                      (`responses-per-second 15`). Set `responsesPerSecond: 0` to disable RRL
+                      entirely. Instance-level config overrides the cluster `global` value.
+
+                      See `RateLimitConfig`.
+                    nullable: true
+                    properties:
+                      responsesPerSecond:
+                        description: |-
+                          Maximum identical responses per second, per client source prefix.
+
+                          Rendered as BIND9's `rate-limit { responses-per-second N; }`. When unset,
+                          a conservative default of `15` is applied (RRL is on by default). Set to
+                          `0` to disable RRL entirely — no `rate-limit` block is emitted.
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
                   recursion:
                     description: |-
                       Enable or disable recursive DNS queries

--- a/deploy/operator/crds/clusterbind9providers.crd.yaml
+++ b/deploy/operator/crds/clusterbind9providers.crd.yaml
@@ -818,6 +818,29 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  rateLimit:
+                    description: |-
+                      Response Rate Limiting (RRL) to mitigate DNS amplification/reflection.
+
+                      When unset, a conservative default is applied
+                      (`responses-per-second 15`). Set `responsesPerSecond: 0` to disable RRL
+                      entirely. Instance-level config overrides the cluster `global` value.
+
+                      See `RateLimitConfig`.
+                    nullable: true
+                    properties:
+                      responsesPerSecond:
+                        description: |-
+                          Maximum identical responses per second, per client source prefix.
+
+                          Rendered as BIND9's `rate-limit { responses-per-second N; }`. When unset,
+                          a conservative default of `15` is applied (RRL is on by default). Set to
+                          `0` to disable RRL entirely — no `rate-limit` block is emitted.
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
                   recursion:
                     description: |-
                       Enable or disable recursive DNS queries

--- a/docs/poetry.lock
+++ b/docs/poetry.lock
@@ -259,14 +259,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.54"
+version = "3.1.59"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf"},
-    {file = "gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0"},
+    {file = "gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c"},
+    {file = "gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4"},
 ]
 
 [package.dependencies]
@@ -274,7 +274,7 @@ gitdb = ">=4.0.1,<5"
 
 [package.extras]
 doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
-test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+test = ["basedpyright (==1.39.9) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "hjson"
@@ -714,14 +714,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 description = "Extension pack for Python Markdown."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"},
-    {file = "pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354"},
+    {file = "pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2"},
+    {file = "pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0"},
 ]
 
 [package.dependencies]
@@ -1001,4 +1001,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a425d5ce1937a17e111d0321ab3ff7943d1c0bfd1f469d85bbdd1a5ee4148c14"
+content-hash = "4ee224e045863c835bf63076d356dd19948e53ea36ae1579b89a388bf7f0bae5"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -24,7 +24,7 @@ mkdocs-redirects = "^1.2.1"
 mkdocs-macros-plugin = "^1.0.5"
 
 # Markdown extensions
-pymdown-extensions = "^10.7"
+pymdown-extensions = "^11.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/docs/src/reference/bind9instance-spec.md
+++ b/docs/src/reference/bind9instance-spec.md
@@ -34,6 +34,8 @@ spec:
     forwarders: [string]
     listenOn: [string]
     listenOnV6: [string]
+    rateLimit:                # Optional, Response Rate Limiting (on by default)
+      responsesPerSecond: integer
   primaryServers: [string]    # Required for secondary role
 ```
 
@@ -414,6 +416,36 @@ spec:
     listenOnV6:
       - "any"              # All IPv6 interfaces
       - "2001:db8::1"      # Specific IPv6
+```
+
+#### global.rateLimit
+**Type**: object
+**Required**: No
+**Default**: `responsesPerSecond: 15` (Response Rate Limiting is **on by default**)
+
+Configures BIND9 Response Rate Limiting (RRL), which throttles identical
+authoritative responses per client source prefix (an IPv4 /24 by default) to
+mitigate DNS amplification and reflection attacks. Because it applies only to
+authoritative answers and is scoped per source prefix, the conservative default
+rarely affects legitimate clients.
+
+Rendered into `named.conf.options` as `rate-limit { responses-per-second N; }`.
+Set `responsesPerSecond: 0` to disable RRL entirely (no `rate-limit` block is
+emitted). Instance-level `spec.config.rateLimit` overrides the cluster
+`global.rateLimit` value.
+
+```yaml
+spec:
+  global:
+    rateLimit:
+      responsesPerSecond: 20   # Tune the cap; omit the block to use the default (15)
+```
+
+```yaml
+spec:
+  config:
+    rateLimit:
+      responsesPerSecond: 0    # Disable RRL for this instance
 ```
 
 ## Status Fields

--- a/src/bind9_resources.rs
+++ b/src/bind9_resources.rs
@@ -658,6 +658,26 @@ fn build_named_conf(instance: &Bind9Instance, cluster: Option<&Bind9Cluster>) ->
         .replace("{{RNDC_KEY_NAMES}}", rndc_key_names)
 }
 
+/// Default `allow-transfer` directive emitted at the options level when no
+/// explicit transfer ACL is configured anywhere (no instance, role, or global
+/// `allow_transfer`).
+///
+/// BIND9's built-in default is `allow-transfer { any; }`, which would expose
+/// every zone served by the instance to AXFR from any client — bulk zone
+/// enumeration (threat model I2) and an amplification vector (D3). We deny by
+/// default instead. Zones that legitimately need transfers get a **zone-level**
+/// `allow-transfer` ACL scoped to their secondary IPs (see
+/// `bind9::zone_ops`), and a zone-level ACL overrides this options-level
+/// default in BIND9 — so replication is unaffected by this hardening.
+const DEFAULT_ALLOW_TRANSFER_NONE: &str = "allow-transfer { none; };";
+
+/// Default `responses-per-second` for BIND9 Response Rate Limiting (RRL) when
+/// `spec.config.rateLimit` is not set. RRL is on by default (threat model
+/// D1/D3 — DNS amplification/reflection); a per-source-prefix cap of 15/s is
+/// ISC's recommended conservative starting point and rarely affects legitimate
+/// clients. Set `rateLimit.responsesPerSecond: 0` in the CRD to disable.
+const DEFAULT_RATE_LIMIT_RESPONSES_PER_SECOND: u32 = 15;
+
 /// Build the named.conf.options configuration from template
 ///
 /// Generates the BIND9 options configuration file from the instance's config spec.
@@ -759,11 +779,12 @@ fn build_options_conf(
                 };
                 allow_transfer = format!("allow-transfer {{ {acl_list}; }};");
             } else {
-                allow_transfer = String::new();
+                // No explicit ACL anywhere — deny by default (see const doc).
+                allow_transfer = DEFAULT_ALLOW_TRANSFER_NONE.to_string();
             }
         } else {
-            // No default - let BIND9 use its own defaults (none)
-            allow_transfer = String::new();
+            // No explicit ACL anywhere — deny by default (see const doc).
+            allow_transfer = DEFAULT_ALLOW_TRANSFER_NONE.to_string();
         }
 
         // DNSSEC configuration - instance overrides global
@@ -822,7 +843,8 @@ fn build_options_conf(
                 };
                 allow_transfer = format!("allow-transfer {{ {acl_list}; }};");
             } else {
-                allow_transfer = String::new();
+                // No explicit ACL anywhere — deny by default (see const doc).
+                allow_transfer = DEFAULT_ALLOW_TRANSFER_NONE.to_string();
             }
 
             // DNSSEC from global
@@ -834,8 +856,8 @@ fn build_options_conf(
         } else {
             // Defaults when no config is specified
             recursion = "recursion no;".to_string();
-            // No default for allow-transfer - let BIND9 use its own defaults (none)
-            allow_transfer = String::new();
+            // No explicit ACL anywhere — deny by default (see const doc).
+            allow_transfer = DEFAULT_ALLOW_TRANSFER_NONE.to_string();
         }
     }
 
@@ -862,6 +884,13 @@ fn build_options_conf(
             .or_else(|| global_config.and_then(|g| g.listen_on_v6.as_ref())),
     )?;
 
+    // Response Rate Limiting - instance overrides global; on by default.
+    let rate_limit = render_rate_limit(
+        instance_cfg
+            .and_then(|c| c.rate_limit.as_ref())
+            .or_else(|| global_config.and_then(|g| g.rate_limit.as_ref())),
+    );
+
     // Perform template substitutions
     Ok(NAMED_CONF_OPTIONS_TEMPLATE
         .replace("{{LISTEN_ON}}", &listen_on)
@@ -870,6 +899,7 @@ fn build_options_conf(
         .replace("{{FORWARDERS}}", &forwarders)
         .replace("{{ALLOW_QUERY}}", &allow_query)
         .replace("{{ALLOW_TRANSFER}}", &allow_transfer)
+        .replace("{{RATE_LIMIT}}", &rate_limit)
         .replace("{{DNSSEC_VALIDATE}}", &dnssec_validate)
         .replace("{{DNSSEC_POLICIES}}", &dnssec_policies))
 }
@@ -910,6 +940,29 @@ fn render_forwarders(forwarders: Option<&Vec<String>>) -> anyhow::Result<String>
         .collect::<Vec<_>>()
         .join("; ");
     Ok(format!("forwarders {{ {joined}; }};"))
+}
+
+/// Render the `rate-limit { responses-per-second N; };` block for
+/// named.conf.options.
+///
+/// Response Rate Limiting (RRL) is **on by default**: when `rate_limit` is
+/// `None`, or its `responses_per_second` is `None`, the conservative default
+/// [`DEFAULT_RATE_LIMIT_RESPONSES_PER_SECOND`] is used. An explicit value of
+/// `0` disables RRL — an empty string is returned so no directive is emitted.
+///
+/// # Arguments
+///
+/// * `rate_limit` - Optional RRL config (instance value takes priority over the
+///   cluster `global` value; resolve that before calling).
+fn render_rate_limit(rate_limit: Option<&crate::crd::RateLimitConfig>) -> String {
+    let rps = rate_limit
+        .and_then(|r| r.responses_per_second)
+        .unwrap_or(DEFAULT_RATE_LIMIT_RESPONSES_PER_SECOND);
+    if rps == 0 {
+        // Explicitly disabled — emit nothing.
+        return String::new();
+    }
+    format!("rate-limit {{ responses-per-second {rps}; }};")
 }
 
 /// Render a `listen-on` / `listen-on-v6` directive for named.conf.options.

--- a/src/bind9_resources_tests.rs
+++ b/src/bind9_resources_tests.rs
@@ -9,7 +9,9 @@ mod tests {
         build_configmap, build_deployment, build_labels_from_instance, build_service,
     };
     use crate::constants::KIND_BIND9_CLUSTER;
-    use crate::crd::{Bind9Config, Bind9Instance, Bind9InstanceSpec, DNSSECConfig};
+    use crate::crd::{
+        Bind9Config, Bind9Instance, Bind9InstanceSpec, DNSSECConfig, RateLimitConfig,
+    };
     use crate::labels::BINDY_MANAGED_BY_LABEL;
     use k8s_openapi::api::core::v1::ServiceSpec;
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -31,6 +33,7 @@ mod tests {
                 image: None,
                 config_map_refs: None,
                 config: Some(Bind9Config {
+                    rate_limit: None,
                     recursion: Some(false),
                     allow_query: Some(vec!["0.0.0.0/0".into()]),
                     allow_transfer: Some(vec!["10.0.0.0/8".into()]),
@@ -699,10 +702,77 @@ mod tests {
         let cm = build_configmap("test", "test-ns", &instance, None, None).unwrap();
         let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
 
-        // Defaults should be applied - recursion no, but NO allow-transfer directive
+        // Defaults should be applied - recursion no.
         assert!(options.contains("recursion no"));
-        // With no config, no allow-transfer directive should be present (BIND9's default: none)
-        assert!(!options.contains("allow-transfer"));
+        // With no config, allow-transfer must be explicitly denied rather than
+        // omitted: an omitted directive falls back to BIND9's default of
+        // `allow-transfer { any; }`, which would expose the zone to AXFR from
+        // anyone. Deny by default instead.
+        assert!(options.contains("allow-transfer { none; }"));
+    }
+
+    #[test]
+    fn test_configmap_with_config_but_no_transfer_acl_denies_by_default() {
+        // A config section exists (recursion/dnssec set) but no allow_transfer
+        // ACL and no cluster — the options-level default must still be `none`,
+        // not an omitted directive (which would inherit BIND9's `any` default).
+        let mut instance = create_test_instance("test");
+        instance.spec.config.as_mut().unwrap().allow_transfer = None;
+
+        let cm = build_configmap("test", "test-ns", &instance, None, None).unwrap();
+        let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
+
+        assert!(options.contains("allow-transfer { none; }"));
+    }
+
+    #[test]
+    fn test_configmap_rate_limit_on_by_default() {
+        // RRL is on by default: no rateLimit configured → conservative default.
+        let instance = create_test_instance("test");
+        let cm = build_configmap("test", "test-ns", &instance, None, None).unwrap();
+        let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
+
+        assert!(options.contains("rate-limit { responses-per-second 15; }"));
+    }
+
+    #[test]
+    fn test_configmap_rate_limit_custom_value() {
+        let mut instance = create_test_instance("test");
+        instance.spec.config.as_mut().unwrap().rate_limit = Some(RateLimitConfig {
+            responses_per_second: Some(50),
+        });
+
+        let cm = build_configmap("test", "test-ns", &instance, None, None).unwrap();
+        let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
+
+        assert!(options.contains("rate-limit { responses-per-second 50; }"));
+        assert!(!options.contains("responses-per-second 15"));
+    }
+
+    #[test]
+    fn test_configmap_rate_limit_disabled_with_zero() {
+        // responsesPerSecond: 0 disables RRL — no directive emitted.
+        let mut instance = create_test_instance("test");
+        instance.spec.config.as_mut().unwrap().rate_limit = Some(RateLimitConfig {
+            responses_per_second: Some(0),
+        });
+
+        let cm = build_configmap("test", "test-ns", &instance, None, None).unwrap();
+        let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
+
+        assert!(!options.contains("rate-limit"));
+    }
+
+    #[test]
+    fn test_configmap_rate_limit_default_when_no_config_section() {
+        // Even a config-less instance gets the default RRL (on by default).
+        let mut instance = create_test_instance("test");
+        instance.spec.config = None;
+
+        let cm = build_configmap("test", "test-ns", &instance, None, None).unwrap();
+        let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
+
+        assert!(options.contains("rate-limit { responses-per-second 15; }"));
     }
 
     #[test]
@@ -1519,6 +1589,7 @@ mod tests {
                     image: None,
                     config_map_refs: None,
                     global: Some(Bind9Config {
+                        rate_limit: None,
                         recursion: Some(true),
                         allow_query: None,
                         allow_transfer: None,
@@ -1924,6 +1995,7 @@ mod tests {
 
         // DNSSEC config exists but signing is not enabled
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -1945,6 +2017,7 @@ mod tests {
 
         // DNSSEC signing explicitly disabled
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -1983,6 +2056,7 @@ mod tests {
 
         // DNSSEC signing enabled with minimal config (all defaults)
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2037,6 +2111,7 @@ mod tests {
 
         // DNSSEC signing enabled with custom values
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2095,6 +2170,7 @@ mod tests {
 
         // Global config enables signing.
         let global_config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2123,6 +2199,7 @@ mod tests {
 
         // Instance config exists but carries no dnssec block at all.
         let instance_config = Bind9Config {
+            rate_limit: None,
             recursion: Some(true),
             allow_query: None,
             allow_transfer: None,
@@ -2149,6 +2226,7 @@ mod tests {
 
         // DNSSEC signing enabled with NSEC3
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2198,6 +2276,7 @@ mod tests {
 
         // Global config with DNSSEC signing
         let global_config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2226,6 +2305,7 @@ mod tests {
 
         // Instance config overrides with different policy
         let instance_config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2292,6 +2372,7 @@ mod tests {
 
         // DNSSEC signing explicitly disabled
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2335,6 +2416,7 @@ mod tests {
 
         // DNSSEC signing with user-supplied Secret
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2409,6 +2491,7 @@ mod tests {
 
         // DNSSEC signing with auto-generated keys
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2472,6 +2555,7 @@ mod tests {
 
         // DNSSEC signing enabled with minimal config - should default to auto-generate
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2522,6 +2606,7 @@ mod tests {
 
         // Global config with auto-generate
         let global_config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,
@@ -2550,6 +2635,7 @@ mod tests {
 
         // Instance config with user-supplied Secret (overrides global)
         let instance_config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: None,
             allow_transfer: None,

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -2288,6 +2288,42 @@ pub struct Bind9Config {
     /// This configuration is inherited by all instances unless overridden.
     #[serde(default)]
     pub bindcar_config: Option<BindcarConfig>,
+
+    /// Response Rate Limiting (RRL) to mitigate DNS amplification/reflection.
+    ///
+    /// When unset, a conservative default is applied
+    /// (`responses-per-second 15`). Set `responsesPerSecond: 0` to disable RRL
+    /// entirely. Instance-level config overrides the cluster `global` value.
+    ///
+    /// See `RateLimitConfig`.
+    #[serde(default)]
+    pub rate_limit: Option<RateLimitConfig>,
+}
+
+/// Response Rate Limiting (RRL) configuration.
+///
+/// BIND9 RRL throttles identical authoritative responses per client source
+/// prefix (an IPv4 /24 by default) to blunt DNS amplification and reflection
+/// attacks (threat model D1/D3). Because it applies only to authoritative
+/// answers and is scoped per source prefix, a modest per-second cap rarely
+/// affects legitimate clients.
+///
+/// # Example
+///
+/// ```yaml
+/// rateLimit:
+///   responsesPerSecond: 20
+/// ```
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitConfig {
+    /// Maximum identical responses per second, per client source prefix.
+    ///
+    /// Rendered as BIND9's `rate-limit { responses-per-second N; }`. When unset,
+    /// a conservative default of `15` is applied (RRL is on by default). Set to
+    /// `0` to disable RRL entirely — no `rate-limit` block is emitted.
+    #[serde(default)]
+    pub responses_per_second: Option<u32>,
 }
 
 /// DNSSEC (DNS Security Extensions) configuration

--- a/src/crd_tests.rs
+++ b/src/crd_tests.rs
@@ -155,6 +155,7 @@ mod tests {
                 image: None,
                 config_map_refs: None,
                 global: Some(Bind9Config {
+                    rate_limit: None,
                     recursion: Some(false),
                     allow_query: None,
                     allow_transfer: None,
@@ -299,6 +300,7 @@ mod tests {
     #[test]
     fn test_bind9_config() {
         let config = Bind9Config {
+            rate_limit: None,
             recursion: Some(false),
             allow_query: Some(vec!["0.0.0.0/0".into()]),
             allow_transfer: Some(vec!["10.0.0.0/8".into()]),
@@ -339,6 +341,7 @@ mod tests {
             image: None,
             config_map_refs: None,
             config: Some(Bind9Config {
+                rate_limit: None,
                 recursion: Some(false),
                 allow_query: None,
                 allow_transfer: None,

--- a/templates/named.conf.options.tmpl
+++ b/templates/named.conf.options.tmpl
@@ -17,6 +17,7 @@ options {
     {{FORWARDERS}}
     {{ALLOW_QUERY}}
     {{ALLOW_TRANSFER}}
+    {{RATE_LIMIT}}
     {{DNSSEC_VALIDATE}}
 };
 


### PR DESCRIPTION
## Summary

Two secure-by-default changes to the generated `named.conf.options`, closing findings P1-3 and P1-4 from the security-remediation roadmap:

### Response Rate Limiting — on by default (P1-3)
- New `RateLimitConfig` CRD field: `spec.config.rateLimit.responsesPerSecond` (inherited from cluster `spec.global`, instance value overrides).
- Rendered as `rate-limit { responses-per-second N; };` via a new `{{RATE_LIMIT}}` placeholder in `templates/named.conf.options.tmpl`.
- **On by default** at 15/s per source /24 (ISC's recommended conservative starting point). `responsesPerSecond: 0` disables RRL entirely (no block emitted).
- Why: the threat model (M-08) claimed BIND9 rate limiting was implemented, but no `rate-limit` directive was ever generated — a false assurance against DNS amplification/reflection (D1/D3). This makes M-08 true.

### Deny AXFR by default (P1-4)
- `build_options_conf` now emits an explicit `allow-transfer { none; };` at the options level whenever no transfer ACL is configured at the instance, role, or global level, instead of omitting the directive and inheriting BIND9's built-in `allow-transfer { any; }`.
- Why: a standalone primary zone with no secondaries and no explicit ACL was open to AXFR from anyone (bulk zone enumeration — I2; amplification — D3), contradicting the model's "AXFR restricted to secondaries" posture (M-07).
- Zones that legitimately need transfers still get a **zone-level** ACL scoped to their secondary IPs (`bind9::zone_ops`), which overrides the options-level default in BIND9 — replication is unaffected.

### Also in this PR
- Regenerated CRDs (`deploy/operator/crds/*.crd.yaml`) and API docs (`docs/src/reference/bind9instance-spec.md`).
- Tests: 4 new RRL tests (default-on, custom value, disabled-with-0, default-when-no-config); corrected `test_configmap_with_no_config_section` and added `test_configmap_with_config_but_no_transfer_acl_denies_by_default`.
- Replaced `CLAUDE.md` with `AGENTS.md` (`CLAUDE.md` is now a symlink to it).
- Bumped `pymdown-extensions` `^10.7 → ^11.0.1` (docs).

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (CRD update + new option in generated config)
- [x] Behavior change: RRL enforced by default (set `responsesPerSecond: 0` to opt out); zones without an explicit transfer ACL now deny AXFR by default

## Testing
- `cargo test`: 1305 passed, 0 failed (run on this branch, rebased on current `main`)