### PR TITLE
fix(operator): substitute RATE_LIMIT in cluster-level named.conf.options

### DIFF
--- a/src/bind9_resources.rs
+++ b/src/bind9_resources.rs
@@ -1106,6 +1106,9 @@ fn build_cluster_options_conf(cluster: &Bind9Cluster) -> anyhow::Result<String> 
         global.and_then(|g| g.listen_on_v6.as_ref()),
     )?;
 
+    // Response Rate Limiting from global config; on by default.
+    let rate_limit = render_rate_limit(global.and_then(|g| g.rate_limit.as_ref()));
+
     Ok(NAMED_CONF_OPTIONS_TEMPLATE
         .replace("{{LISTEN_ON}}", &listen_on)
         .replace("{{LISTEN_ON_V6}}", &listen_on_v6)
@@ -1113,6 +1116,7 @@ fn build_cluster_options_conf(cluster: &Bind9Cluster) -> anyhow::Result<String> 
         .replace("{{FORWARDERS}}", &forwarders)
         .replace("{{ALLOW_QUERY}}", &allow_query)
         .replace("{{ALLOW_TRANSFER}}", &allow_transfer)
+        .replace("{{RATE_LIMIT}}", &rate_limit)
         .replace("{{DNSSEC_VALIDATE}}", &dnssec_validate)
         .replace("{{DNSSEC_POLICIES}}", &dnssec_policies))
 }

--- a/src/bind9_resources_tests.rs
+++ b/src/bind9_resources_tests.rs
@@ -1672,6 +1672,51 @@ mod tests {
     }
 
     #[test]
+    fn test_cluster_options_conf_substitutes_rate_limit_placeholder() {
+        // Regression: #466 added {{RATE_LIMIT}} to named.conf.options.tmpl but only
+        // substituted it in the instance-level builder. The cluster-level builder
+        // shipped the literal placeholder, and named exits on the syntax error
+        // ("'}' expected near '{'"), crash-looping every operand pod.
+        use crate::bind9_resources::build_cluster_configmap;
+        use crate::crd::{Bind9Cluster, Bind9ClusterCommonSpec, Bind9ClusterSpec};
+
+        let cluster = Bind9Cluster {
+            metadata: ObjectMeta {
+                name: Some("test-cluster".to_string()),
+                namespace: Some("test-ns".to_string()),
+                ..Default::default()
+            },
+            spec: Bind9ClusterSpec {
+                common: Bind9ClusterCommonSpec {
+                    version: None,
+                    primary: None,
+                    secondary: None,
+                    image: None,
+                    config_map_refs: None,
+                    global: None,
+                    rndc_secret_refs: None,
+                    acls: None,
+                    volumes: None,
+                    volume_mounts: None,
+                },
+            },
+            status: None,
+        };
+
+        let cm = build_cluster_configmap("test-cluster", "test-ns", &cluster).unwrap();
+        let options = cm.data.unwrap().get("named.conf.options").unwrap().clone();
+
+        assert!(
+            options.contains("rate-limit { responses-per-second 15; };"),
+            "cluster default RRL must be rendered, got: {options}"
+        );
+        assert!(
+            !options.contains("{{"),
+            "no template placeholder may survive substitution, got: {options}"
+        );
+    }
+
+    #[test]
     fn test_service_api_port_default() {
         // Test default API port (8080) when no bindcar_config is specified
         let instance = create_test_instance("test");


### PR DESCRIPTION
## Problem

`#466` added the `{{RATE_LIMIT}}` placeholder to `templates/named.conf.options.tmpl` and substituted it in the **instance-level** builder (`build_options_conf`), but not in the **cluster-level** builder (`build_cluster_options_conf`). Every cluster ConfigMap therefore shipped the literal placeholder, and `named` exited at startup:

```
/etc/bind/named.conf.options:20: '}' expected near '{'
loading configuration: unexpected token
exiting (due to fatal error)
```

The `bind9` operand container crash-loops, pods never become Ready, and the e2e suite fails (`test_instance_pod_label_selector_finds_pods`: pods never Ready within 4 minutes) — on `main` itself and on every PR rebased onto it (currently blocking dependabot PRs #461–#465).

## Root-cause verification (local, kind)

- Reproduced on `main` (53df509): 11 passed, 1 failed — same test as CI.
- Pre-#466 commit (2d8d7b4): full integration suite passes.
- Patching the live ConfigMap to substitute the placeholder: operand pod goes 2/2 Ready in ~30s.

## Fix

- `build_cluster_options_conf` now renders `rate-limit` from `spec.global.rateLimit` (default 15/s per source /24, `responsesPerSecond: 0` disables) and substitutes `{{RATE_LIMIT}}`, matching the instance-level builder.
- Regression test asserts the default directive is rendered and that **no template placeholder survives substitution** — the existing cluster-config tests only checked forwarders/listen-on, which is why 47/47 unit tests passed with this bug.

## Note (follow-up, not in this PR)

The cluster-level builder also never received the `allow-transfer { none; }` deny-by-default from #466 — same class of gap, separate change.

## Test plan

- `cargo test --all` — 1300+ tests green, incl. new regression test
- `cargo fmt --check`, `cargo clippy --all -- -D warnings` — clean
- Local kind e2e on main reproduced the failure; ConfigMap patch confirmed the fix path