### PR TITLE
chore(deps): combined dependabot updates (base64, action-gh-release, paths-filter, license-check)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -951,7 +951,7 @@ jobs:
           ls -lh ../vex/ || echo "No VEX documents found"
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
             artifacts/release/*.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check license headers
-        uses: firestoned/github-actions/security/license-check@53b483254bc648903c364ee3c73a546d0936a91e # v1.3.6
+        uses: firestoned/github-actions/security/license-check@d0d51c638a90bffc2a1567fe7af112b37fe8854c # v1.3.7
         with:
           copyright-holder: "Erick Bourgeois, firestoned"
           license-id: "MIT"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
           filters: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bindcar"
@@ -306,7 +306,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bindcar",
  "chrono",
  "clap",


### PR DESCRIPTION
Combines four open dependabot PRs into a single branch — one CI cycle instead of four serialized ones (the `main` ruleset requires up-to-date branches + linear history, so each individual merge forces a rebase + full CI re-run on every other open PR).

Included (cherry-picked, GPG-signed, signoffs preserved):

- #461 — deps: bump base64 0.23.0 → 0.23.1 (rust-dependencies group)
- #463 — ci: bump softprops/action-gh-release 3.0.1 → 3.0.2
- #464 — ci: bump dorny/paths-filter 4.0.1 → 4.0.3
- #465 — ci: bump firestoned/github-actions/security/license-check 1.3.6 → 1.3.7

All four branches were fully green (builds, clippy, security scan, kind e2e gate) before being invalidated by merges to main. `cargo test --all` passes on the combined branch.

Once this merges I'll close the four individual PRs as superseded.