### PR TITLE
ci(dependabot): group cargo and github-actions updates into one PR each

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,8 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Group minor and patch updates together
+    # Group all updates together: one weekly PR for kube-ecosystem (which must
+    # move as a unit) and one for everything else, instead of a PR per crate.
     groups:
       # The kube ecosystem is tightly version-coupled: kube 4.x requires
       # k8s-openapi 0.28, and kube-lease-manager pins a specific kube minor.
@@ -44,6 +45,7 @@ updates:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
@@ -64,6 +66,17 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # Group all action bumps into a single weekly PR — one CI cycle instead of
+    # a serialized chain (the main ruleset requires up-to-date branches, so N
+    # separate PRs cost N full CI runs).
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
 
   # Docker base images
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Why

The `main` ruleset requires up-to-date branches with linear history: every merge marks all other open PRs BEHIND, forcing a rebase + full ~20-min CI cycle per PR. Five separate github-actions PRs (#460, #462–#465) recently cost five serialized CI runs, and any unrelated merge reset the whole chain.

## What changes

- **cargo**: the `rust-dependencies` catch-all group now includes majors. Dependabot opens at most two weekly cargo PRs: `kube-ecosystem` (unchanged — kube/k8s-openapi/kube-lease-manager are version-coupled and must move as a unit) + everything else.
- **github-actions**: new catch-all group covering all update types → one weekly PR for all action bumps.

## Behavior note

A major bump inside a grouped PR makes the whole PR report `version-update:semver-major`, so the dependabot auto-merge workflow holds it for manual review — the fail-safe behavior is unchanged. No effect on already-open PRs beyond dependabot rebasing them into the new grouping on its next run.