### PR TITLE
feat: multi zone pod spread

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -1,3 +1,47 @@
+## Zone spreading review round 3 (PR #473)
+
+### Fixed
+- `docs/src/guide/zone-spreading.md`: `topologyKey` documented as 1–316 chars; the schema
+  and ADR-0003 both say 317 (253 prefix + `/` + 63 name). Also documented the `maxSkew`
+  (1–100), `minDomains` (1–1000) and 253-char-prefix bounds.
+- `docs/src/installation/crds.md`: removed a reference to `placement.affinity`, which does
+  not exist — the affinity/tolerations passthrough was dropped per ADR-0003. Replaced the
+  "Updating Existing CRDs" instruction to use `kubectl apply --server-side` instead of
+  `kubectl replace --force -f deploy/crds/`, which pointed at a nonexistent path AND would
+  have cascaded a CRD delete to every custom resource.
+- `deploy/kind-config-multizone.yaml`: dropped a reference to
+  `deploy/admission-policies/17-bindy-placement-policy.yaml`, deleted in the previous round.
+- `src/bind9_resources.rs`: `build_pod_spec` docstring still listed node selector /
+  tolerations / affinity as placement inputs.
+- Completed the `deploy/crds/` → `deploy/operator/crds/` path cleanup across 12 docs, plus
+  dead `deploy/controller/` and `deploy/rbac/` paths in `deploy/README.md` /
+  `deploy/TESTING.md`. Every `deploy/` path referenced by the touched docs now exists.
+
+### Added
+- `tests/zone_spread_test.sh` is now self-contained: creates its own three-zone kind
+  cluster, installs CRDs (server-side) and RBAC, and deploys the operator. Takes
+  `--image` / `--skip-deploy` like `tests/integration_test.sh`, addresses the cluster
+  through an explicit `--context` rather than the ambient one, and no longer needs
+  `python3`.
+- CI wiring: new `make zone-spread-test` target; `make ci-e2e` now runs the suite as a
+  third stage; `e2e.yaml` gains path triggers for the placement sources and dumps
+  diagnostics for the new cluster. Previously the suite was manual-only.
+- Unit coverage for the convergence machinery, which had none: `deployment_needs_update`
+  (constraint added / changed / removed, stale pod labels, and a no-op guard against a
+  hot-patch loop), `build_placement_patch` (the `$patch: replace` directive and the
+  `null` removal path), `deployment_labels_are_current` (the upgrade regression, foreign
+  labels, missing labels), and `validate_user_pod_shape`'s placement block including a
+  shadowed-but-invalid role block. 17 tests; mutation-checked.
+
+### Changed
+- Extracted the reconcile short-circuit's label comparison from
+  `reconcilers/bind9instance/mod.rs` into `deployment_labels_are_current`, so it can be
+  tested without a live API server.
+- Test flake fixes: TEST 3 (zone occupancy) is informational — the default rule is
+  `ScheduleAnyway`, so even distribution is scheduler scoring, not a contract; TEST 5
+  makes the contractual claim. TEST 8 waits for the secondary rollout instead of
+  `sleep 10`. TEST 4's rollout wait no longer swallows failures with `|| true`.
+
 ## [2026-07-21] - Fix CI: cargo fmt and clippy failures in PR #445's new gateway-resolution tests
 
 **Author:** Erick Bourgeois

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,11 @@
 #   1. Integration suite   — simple zone/record lifecycle (tests/integration_test.sh)
 #   2. Regression suite     — admission policies + operand pod-shape + liveness
 #                             (tests/regression_test.sh: bindcar 0.7.x Mode B contract)
+#   3. Zone-spreading suite — spec.placement topology spread, on a three-zone
+#                             cluster (tests/zone_spread_test.sh). Needs its own
+#                             cluster: deploy/kind-config-multizone.yaml labels
+#                             three workers with distinct availability zones,
+#                             which the single-node config cannot express.
 #
 # All logic lives in the `ci-e2e` Makefile target (workflows delegate to the
 # Makefile per repo convention). Self-contained: no pushed image, no
@@ -24,6 +29,14 @@ on:
       - '.github/workflows/e2e.yaml'
       - 'Makefile'
       - 'rust-toolchain.toml'
+      # Scheduling behaviour is only observable against a real scheduler, so
+      # changes to it must run the kind gate.
+      - 'src/placement.rs'
+      - 'src/bind9_resources.rs'
+      - 'src/reconcilers/bind9instance/**'
+      - 'tests/zone_spread_test.sh'
+      - 'deploy/kind-config-multizone.yaml'
+      - 'deploy/operator/crds/**'
   workflow_call: {}
   workflow_dispatch: {}
 
@@ -36,7 +49,7 @@ env:
 
 jobs:
   e2e:
-    name: Integration + Regression (kind)
+    name: Integration + Regression + Zone Spread (kind)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -67,7 +80,7 @@ jobs:
       - name: Dump Kubernetes diagnostics on failure
         if: failure()
         run: |
-          for ctx in kind-bindy-e2e kind-bindy-regression; do
+          for ctx in kind-bindy-e2e kind-bindy-regression kind-bindy-e2e-zonespread; do
             echo "::group::cluster summary ($ctx)"
             kubectl --context "$ctx" get nodes -o wide 2>/dev/null || true
             kubectl --context "$ctx" get ns 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,11 @@ crds-combined: crds ## Generate combined crds.yaml file for releases
 	@echo "# SPDX-License-Identifier: MIT" >> deploy/crds.yaml
 	@echo "#" >> deploy/crds.yaml
 	@echo "# Combined CRD definitions for Bindy" >> deploy/crds.yaml
-	@echo "# Install with: kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml" >> deploy/crds.yaml
+	@echo "# Install with: kubectl apply --server-side -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml" >> deploy/crds.yaml
+	@echo "#" >> deploy/crds.yaml
+	@echo "# --server-side is REQUIRED: the cluster CRDs exceed the 256KB" >> deploy/crds.yaml
+	@echo "# kubectl.kubernetes.io/last-applied-configuration annotation limit that" >> deploy/crds.yaml
+	@echo "# client-side apply relies on, and a plain 'kubectl apply' fails outright." >> deploy/crds.yaml
 	@echo "#" >> deploy/crds.yaml
 	@echo "# DO NOT EDIT MANUALLY - Generated from individual CRD files in deploy/operator/crds/" >> deploy/crds.yaml
 	@echo "---" >> deploy/crds.yaml
@@ -782,8 +786,15 @@ regression-test-fresh: ## Run the regression suite on a freshly recreated kind c
 	@chmod +x tests/regression_test.sh
 	@CLUSTER_NAME=$(REGRESSION_CLUSTER) tests/regression_test.sh --fresh $(if $(REGRESSION_IMAGE),--image "$(REGRESSION_IMAGE)")
 
+ZONESPREAD_CLUSTER ?= bindy-zonespread
+
+zone-spread-test: ## Run the zone-spreading e2e on a fresh three-zone kind cluster (topology spread across failure domains)
+	@chmod +x tests/zone_spread_test.sh
+	@CLUSTER_NAME=$(ZONESPREAD_CLUSTER) tests/zone_spread_test.sh $(if $(ZONESPREAD_IMAGE),--image "$(ZONESPREAD_IMAGE)")
+
 CI_E2E_IMAGE ?= ghcr.io/firestoned/bindy:ci-e2e
 CI_E2E_INTEGRATION_CLUSTER ?= bindy-e2e
+CI_E2E_ZONESPREAD_CLUSTER ?= bindy-e2e-zonespread
 
 ci-e2e: ## Self-contained full e2e: build local image, run integration + regression against it (no registry). Used by the e2e.yaml workflow.
 	@echo "==> Building operator image locally ($(CI_E2E_IMAGE))"
@@ -793,9 +804,13 @@ ci-e2e: ## Self-contained full e2e: build local image, run integration + regress
 	@CLUSTER_NAME=$(CI_E2E_INTEGRATION_CLUSTER) tests/integration_test.sh --image "$(CI_E2E_IMAGE)"
 	@echo "==> Regression suite (admission policies + operand pod-shape + liveness) against $(CI_E2E_IMAGE)"
 	@$(MAKE) regression-test-fresh REGRESSION_IMAGE=$(CI_E2E_IMAGE)
+	@echo "==> Zone-spreading suite (topology spread on a 3-zone cluster) against $(CI_E2E_IMAGE)"
+	@chmod +x tests/zone_spread_test.sh
+	@CLUSTER_NAME=$(CI_E2E_ZONESPREAD_CLUSTER) tests/zone_spread_test.sh --image "$(CI_E2E_IMAGE)"
 	@echo "==> Cleaning up e2e kind clusters"
 	@kind delete cluster --name $(CI_E2E_INTEGRATION_CLUSTER) 2>/dev/null || true
 	@kind delete cluster --name $(REGRESSION_CLUSTER) 2>/dev/null || true
+	@kind delete cluster --name $(CI_E2E_ZONESPREAD_CLUSTER) 2>/dev/null || true
 
 # ── CALM (Architecture as Code) ──────────────────────────────────────────────
 # FINOS CALM models live in ./calm; the Mermaid diagrams under

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Useful for testing or when you need full control over a single instance.
 ✅ **Cluster-Scoped** - ClusterBind9Provider for platform-managed DNS
 ✅ **DNSSEC** - Automatic key management and zone signing
 ✅ **High Availability** - Leader election, automatic failover
+✅ **Zone-Aware Scheduling** - Spread nameservers across availability zones, racks, or any node topology ([guide](docs/src/guide/zone-spreading.md))
 ✅ **Compliance** - SOX, NIST 800-53, CIS documented
 ✅ **Secure** - Non-root containers, RBAC, signed releases
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -96,7 +96,7 @@ For production clusters, use the latest stable release:
 kubectl create namespace bindy-system
 
 # 2. Install CRDs
-kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml
+kubectl apply --server-side -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml
 
 # 3. Install RBAC
 kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/rbac/serviceaccount.yaml
@@ -117,10 +117,12 @@ For development or custom builds:
 
 #### 1. Install CRDs
 
-Use kustomize to apply the split CRD manifests:
+Use kustomize to apply the split CRD manifests. `--server-side` is required:
+the cluster CRDs exceed the 256 KB `last-applied-configuration` annotation
+limit that client-side apply relies on.
 
 ```bash
-kubectl apply -k deploy/crds
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
 #### 2. Create Namespace
@@ -132,7 +134,7 @@ kubectl create namespace bindy-system
 #### 3. Install RBAC
 
 ```bash
-kubectl apply -f deploy/rbac/
+kubectl apply -f deploy/operator/rbac/
 ```
 
 #### 4. Build and Push Image
@@ -251,7 +253,7 @@ kubectl logs -n bindy-system -l app=bindy | grep ERROR
 ### Upgrade CRDs
 
 ```bash
-kubectl apply -k deploy/crds
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
 ### Upgrade Operator
@@ -274,13 +276,13 @@ kubectl rollout status deployment/bindy -n bindy-system
 
 ```bash
 # Delete operator
-kubectl delete -f deploy/controller/deployment.yaml
+kubectl delete -f deploy/operator/deployment.yaml
 
 # Delete RBAC
-kubectl delete -f deploy/rbac/
+kubectl delete -f deploy/operator/rbac/
 
 # Delete CRDs (this will delete all custom resources!)
-kubectl delete -k deploy/crds
+kubectl delete -f deploy/operator/crds/
 
 # Delete namespace
 kubectl delete namespace bindy-system

--- a/deploy/TESTING.md
+++ b/deploy/TESTING.md
@@ -88,7 +88,7 @@ kind load docker-image bindy:latest --name bindy-test
 ### Step 3: Deploy CRDs
 
 ```bash
-kubectl apply -k deploy/crds/
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
 Verify CRDs are installed:
@@ -118,7 +118,7 @@ txtrecords.dns.firestoned.io
 kubectl create namespace bindy-system
 
 # Deploy RBAC
-kubectl apply -f deploy/rbac/
+kubectl apply -f deploy/operator/rbac/
 
 # Deploy operator
 kubectl apply -f deploy/operator/deployment.yaml
@@ -446,8 +446,8 @@ kubectl delete arecords,txtrecords,cnamerecords,dnszones,bind9instances --all -n
 
 ```bash
 kubectl delete -f deploy/operator/deployment.yaml
-kubectl delete -f deploy/rbac/
-kubectl delete -f deploy/crds/dns-crds.yaml
+kubectl delete -f deploy/operator/rbac/
+kubectl delete -f deploy/operator/crds/
 kubectl delete namespace bindy-system
 ```
 
@@ -474,8 +474,8 @@ Example GitHub Actions workflow snippet:
   run: |
     docker build -t bindy:test .
     kind load docker-image bindy:test --name bindy-test
-    kubectl apply -k deploy/crds/
-    kubectl apply -f deploy/rbac/
+    kubectl apply --server-side -f deploy/operator/crds/
+    kubectl apply -f deploy/operator/rbac/
     kubectl apply -f deploy/operator/
 
 - name: Run Tests

--- a/deploy/kind-config-multizone.yaml
+++ b/deploy/kind-config-multizone.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# A kind cluster that fakes a three-zone cloud region, for exercising
+# `spec.placement` topology spreading locally.
+#
+# kind nodes are containers on one host, so there are no real failure domains
+# here. What matters to the scheduler is only the node label: it buckets nodes
+# by the value of `topology.kubernetes.io/zone` and balances Pods across those
+# buckets. Labelling three workers `zone-a` / `zone-b` / `zone-c` therefore
+# reproduces multi-zone scheduling behaviour exactly, without a cloud account.
+#
+# The control-plane node is deliberately left unlabelled and keeps its default
+# NoSchedule taint, so it forms no zone and takes no DNS Pods. Three zones is
+# the minimum that makes maxSkew: 1 interesting: with two, every placement is
+# trivially balanced.
+#
+# Usage:
+#   kind create cluster --config deploy/kind-config-multizone.yaml
+#   ./tests/zone_spread_test.sh
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: bindy-multizone
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "topology.kubernetes.io/zone=zone-a,topology.kubernetes.io/region=local,node-tier=dns"
+  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "topology.kubernetes.io/zone=zone-b,topology.kubernetes.io/region=local,node-tier=dns"
+  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "topology.kubernetes.io/zone=zone-c,topology.kubernetes.io/region=local,node-tier=dns"

--- a/deploy/kind-deploy.sh
+++ b/deploy/kind-deploy.sh
@@ -86,8 +86,11 @@ EOF
 fi
 
 echo -e "${GREEN}📋 Installing CRDs...${NC}"
-# Use 'kubectl replace --force' to avoid annotation size limits with large CRDs
-kubectl replace --force -f deploy/operator/crds 2>/dev/null || kubectl create -f deploy/operator/crds
+# Server-side apply: the cluster CRDs exceed the 256KB last-applied-configuration
+# annotation that client-side apply relies on. Note this replaces an earlier
+# `kubectl replace --force`, which deleted and recreated the CRDs — taking every
+# existing custom resource with them.
+kubectl apply --server-side --force-conflicts -f deploy/operator/crds
 
 echo -e "${GREEN}🔐 Creating namespace and RBAC...${NC}"
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -

--- a/deploy/operator/crds/bind9clusters.crd.yaml
+++ b/deploy/operator/crds/bind9clusters.crd.yaml
@@ -973,6 +973,192 @@ spec:
                       by `DNSZone` resources using `bind9InstancesFrom.selector.matchLabels`.
                     nullable: true
                     type: object
+                  placement:
+                    description: |-
+                      Topology spreading for all primary instances in this cluster.
+
+                      This is the level most users want: it spreads every primary nameserver
+                      of the cluster across failure domains, which is exactly what protects
+                      against a zone outage taking out authoritative DNS.
+
+                      When unset, the operator applies a soft zone-spread default as soon as
+                      `primary.replicas` is 2 or more. Overridden per-server by
+                      `Bind9Instance.spec.placement`.
+
+                      # Example
+
+                      ```yaml
+                      primary:
+                        replicas: 3
+                        placement:
+                          spread:
+                            - topologyKey: topology.kubernetes.io/zone
+                              maxSkew: 1
+                              whenUnsatisfiable: DoNotSchedule
+                      ```
+                    nullable: true
+                    properties:
+                      spread:
+                        description: |-
+                          Topology spread rules applied to the Pods of this DNS server.
+
+                          Three distinct states:
+
+                          - **absent** — for a **primary** role with two or more servers, the
+                            operator applies its default: one soft (`ScheduleAnyway`) rule over
+                            `topology.kubernetes.io/zone` with `maxSkew: 1`. Secondaries and
+                            single-server roles get no constraint unless you ask for one.
+                          - **empty list** (`spread: []`) — explicitly no spread constraints.
+                            Use this to opt a multi-primary cluster out of the default.
+                          - **non-empty list** — exactly these rules, and no default. This is how
+                            secondaries opt *in*.
+
+                          At most 8 rules; each becomes one `topologySpreadConstraint`, and every
+                          constraint is re-evaluated on each scheduling attempt.
+                        items:
+                          description: |-
+                            A single topology spread rule.
+
+                            Each rule becomes exactly one entry in the Pod's
+                            `spec.topologySpreadConstraints`, with the `labelSelector` generated from
+                            [`SpreadScope`] rather than written by hand — users have no way to know the
+                            operator's internal Pod labels, and getting the selector wrong silently
+                            produces a constraint that does nothing.
+
+                            # Example
+
+                            ```yaml
+                            spread:
+                              # Spread primaries across zones first — hard requirement.
+                              - topologyKey: topology.kubernetes.io/zone
+                                maxSkew: 1
+                                whenUnsatisfiable: DoNotSchedule
+                                scope: Role
+                              # Then, within a zone, prefer separate nodes.
+                              - topologyKey: kubernetes.io/hostname
+                                maxSkew: 1
+                                whenUnsatisfiable: ScheduleAnyway
+                                scope: Role
+                            ```
+                          properties:
+                            maxSkew:
+                              description: |-
+                                Maximum permitted difference in Pod count between any two domains.
+
+                                Default: `1` (the tightest useful value — every domain is filled before
+                                any domain doubles up).
+                              format: int32
+                              maximum: 100.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            minDomains:
+                              description: |-
+                                Minimum number of domains that must be eligible.
+
+                                Only meaningful together with `whenUnsatisfiable: DoNotSchedule`. When
+                                fewer than `minDomains` domains exist, the constraint is treated as
+                                unsatisfiable. Use it to fail loudly rather than silently running all
+                                your nameservers in one zone.
+                              format: int32
+                              maximum: 1000.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            scope:
+                              description: |-
+                                Which set of DNS Pods a spread rule balances across failure domains.
+
+                                This is the field that makes zone spreading actually work in Bindy, and it
+                                exists because a DNS server is not an anonymous replica.
+
+                                A `Bind9Cluster` with `primary.replicas: 3` does **not** create one
+                                three-Pod Deployment. Each primary is an individually addressable
+                                nameserver (its hostname ends up in an `NS` record), so the cluster
+                                controller creates three separate `Bind9Instance` resources, each backed by
+                                its own single-Pod Deployment. A spread constraint whose label selector
+                                matches only its own Deployment's Pods would therefore balance a set of
+                                size one — which is always trivially balanced, and spreads nothing.
+
+                                `scope` selects the label selector the operator generates, and so decides
+                                which Pods the scheduler counts per domain.
+                              enum:
+                              - Instance
+                              - Role
+                              - Cluster
+                              nullable: true
+                              type: string
+                            topologyKey:
+                              description: |-
+                                Node label key that defines the failure domain.
+
+                                Nodes sharing a value for this label are in the same domain. Any node
+                                label works, which is the point: clusters that do not use the
+                                well-known zone label can spread across whatever they do use.
+
+                                Examples:
+                                - `topology.kubernetes.io/zone` - availability zone (the usual choice)
+                                - `topology.kubernetes.io/region` - region, for multi-region clusters
+                                - `kubernetes.io/hostname` - individual nodes
+                                - `failure-domain.acme.io/rack` - a custom, on-prem failure domain
+                                - `karpenter.sh/capacity-type` - spot vs. on-demand capacity
+
+                                Must be a valid Kubernetes qualified name, matching what the API server
+                                accepts for a node label key: an optional lowercase RFC 1123 subdomain
+                                prefix of at most 253 characters, a `/`, and a name segment of at most
+                                63 characters. The maximum overall length is therefore 317.
+
+                                The 253-character prefix cap is enforced by an
+                                `x-kubernetes-validations` rule on the parent rule rather than by the
+                                pattern below: CRD patterns are RE2, which has no lookahead, so a
+                                length bound on a variable-length prefix cannot be expressed in the
+                                regex itself.
+                              maxLength: 317
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                How the scheduler should react when a spread rule cannot be satisfied.
+
+                                Mirrors Kubernetes `topologySpreadConstraints[].whenUnsatisfiable`.
+                              enum:
+                              - DoNotSchedule
+                              - ScheduleAnyway
+                              nullable: true
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                          x-kubernetes-validations:
+                          - message: 'minDomains is only valid together with whenUnsatisfiable: DoNotSchedule'
+                            rule: '!has(self.minDomains) || (has(self.whenUnsatisfiable) && self.whenUnsatisfiable == ''DoNotSchedule'')'
+                          - message: topologyKey prefix (the part before '/') must be at most 253 characters
+                            rule: self.topologyKey.indexOf('/') <= 253
+                        maxItems: 8
+                        nullable: true
+                        type: array
+                    type: object
                   replicas:
                     description: |-
                       Number of primary instance replicas (default: 1)
@@ -1585,6 +1771,193 @@ spec:
                       These labels will appear on the `Bind9Instance` metadata and can be referenced
                       by `DNSZone` resources using `bind9InstancesFrom.selector.matchLabels`.
                     nullable: true
+                    type: object
+                  placement:
+                    description: |-
+                      Topology spreading for all secondary instances in this cluster.
+
+                      **No default applies here.** The operator's automatic zone spread is
+                      limited to primaries, which is what issue #467 asked for and what a
+                      zone outage most threatens: primaries are authoritative and, unlike
+                      secondaries, cannot be re-created from another server's data. Silently
+                      changing where existing secondary workloads schedule would be an
+                      unannounced policy change on a running cluster.
+
+                      Secondaries therefore opt in explicitly:
+
+                      ```yaml
+                      secondary:
+                        replicas: 3
+                        placement:
+                          spread:
+                            - topologyKey: topology.kubernetes.io/zone
+                              maxSkew: 1
+                              whenUnsatisfiable: ScheduleAnyway
+                      ```
+
+                      See `PrimaryConfig.placement` for field documentation.
+                    nullable: true
+                    properties:
+                      spread:
+                        description: |-
+                          Topology spread rules applied to the Pods of this DNS server.
+
+                          Three distinct states:
+
+                          - **absent** — for a **primary** role with two or more servers, the
+                            operator applies its default: one soft (`ScheduleAnyway`) rule over
+                            `topology.kubernetes.io/zone` with `maxSkew: 1`. Secondaries and
+                            single-server roles get no constraint unless you ask for one.
+                          - **empty list** (`spread: []`) — explicitly no spread constraints.
+                            Use this to opt a multi-primary cluster out of the default.
+                          - **non-empty list** — exactly these rules, and no default. This is how
+                            secondaries opt *in*.
+
+                          At most 8 rules; each becomes one `topologySpreadConstraint`, and every
+                          constraint is re-evaluated on each scheduling attempt.
+                        items:
+                          description: |-
+                            A single topology spread rule.
+
+                            Each rule becomes exactly one entry in the Pod's
+                            `spec.topologySpreadConstraints`, with the `labelSelector` generated from
+                            [`SpreadScope`] rather than written by hand — users have no way to know the
+                            operator's internal Pod labels, and getting the selector wrong silently
+                            produces a constraint that does nothing.
+
+                            # Example
+
+                            ```yaml
+                            spread:
+                              # Spread primaries across zones first — hard requirement.
+                              - topologyKey: topology.kubernetes.io/zone
+                                maxSkew: 1
+                                whenUnsatisfiable: DoNotSchedule
+                                scope: Role
+                              # Then, within a zone, prefer separate nodes.
+                              - topologyKey: kubernetes.io/hostname
+                                maxSkew: 1
+                                whenUnsatisfiable: ScheduleAnyway
+                                scope: Role
+                            ```
+                          properties:
+                            maxSkew:
+                              description: |-
+                                Maximum permitted difference in Pod count between any two domains.
+
+                                Default: `1` (the tightest useful value — every domain is filled before
+                                any domain doubles up).
+                              format: int32
+                              maximum: 100.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            minDomains:
+                              description: |-
+                                Minimum number of domains that must be eligible.
+
+                                Only meaningful together with `whenUnsatisfiable: DoNotSchedule`. When
+                                fewer than `minDomains` domains exist, the constraint is treated as
+                                unsatisfiable. Use it to fail loudly rather than silently running all
+                                your nameservers in one zone.
+                              format: int32
+                              maximum: 1000.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            scope:
+                              description: |-
+                                Which set of DNS Pods a spread rule balances across failure domains.
+
+                                This is the field that makes zone spreading actually work in Bindy, and it
+                                exists because a DNS server is not an anonymous replica.
+
+                                A `Bind9Cluster` with `primary.replicas: 3` does **not** create one
+                                three-Pod Deployment. Each primary is an individually addressable
+                                nameserver (its hostname ends up in an `NS` record), so the cluster
+                                controller creates three separate `Bind9Instance` resources, each backed by
+                                its own single-Pod Deployment. A spread constraint whose label selector
+                                matches only its own Deployment's Pods would therefore balance a set of
+                                size one — which is always trivially balanced, and spreads nothing.
+
+                                `scope` selects the label selector the operator generates, and so decides
+                                which Pods the scheduler counts per domain.
+                              enum:
+                              - Instance
+                              - Role
+                              - Cluster
+                              nullable: true
+                              type: string
+                            topologyKey:
+                              description: |-
+                                Node label key that defines the failure domain.
+
+                                Nodes sharing a value for this label are in the same domain. Any node
+                                label works, which is the point: clusters that do not use the
+                                well-known zone label can spread across whatever they do use.
+
+                                Examples:
+                                - `topology.kubernetes.io/zone` - availability zone (the usual choice)
+                                - `topology.kubernetes.io/region` - region, for multi-region clusters
+                                - `kubernetes.io/hostname` - individual nodes
+                                - `failure-domain.acme.io/rack` - a custom, on-prem failure domain
+                                - `karpenter.sh/capacity-type` - spot vs. on-demand capacity
+
+                                Must be a valid Kubernetes qualified name, matching what the API server
+                                accepts for a node label key: an optional lowercase RFC 1123 subdomain
+                                prefix of at most 253 characters, a `/`, and a name segment of at most
+                                63 characters. The maximum overall length is therefore 317.
+
+                                The 253-character prefix cap is enforced by an
+                                `x-kubernetes-validations` rule on the parent rule rather than by the
+                                pattern below: CRD patterns are RE2, which has no lookahead, so a
+                                length bound on a variable-length prefix cannot be expressed in the
+                                regex itself.
+                              maxLength: 317
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                How the scheduler should react when a spread rule cannot be satisfied.
+
+                                Mirrors Kubernetes `topologySpreadConstraints[].whenUnsatisfiable`.
+                              enum:
+                              - DoNotSchedule
+                              - ScheduleAnyway
+                              nullable: true
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                          x-kubernetes-validations:
+                          - message: 'minDomains is only valid together with whenUnsatisfiable: DoNotSchedule'
+                            rule: '!has(self.minDomains) || (has(self.whenUnsatisfiable) && self.whenUnsatisfiable == ''DoNotSchedule'')'
+                          - message: topologyKey prefix (the part before '/') must be at most 253 characters
+                            rule: self.topologyKey.indexOf('/') <= 253
+                        maxItems: 8
+                        nullable: true
+                        type: array
                     type: object
                   replicas:
                     description: |-

--- a/deploy/operator/crds/bind9instances.crd.yaml
+++ b/deploy/operator/crds/bind9instances.crd.yaml
@@ -1205,6 +1205,181 @@ spec:
                     nullable: true
                     type: array
                 type: object
+              placement:
+                description: |-
+                  Topology spreading for this one DNS server's Pods.
+
+                  Highest-priority placement level: set here, it wins outright over the
+                  role-level block rather than merging with it.
+
+                  For a standalone `Bind9Instance` with `spec.replicas` of 2 or more,
+                  the default spread scope is `Instance` — the instance's own replicas
+                  are balanced across zones. For a cluster-managed instance (one Pod
+                  each) the default scope is `Role`, balancing this Pod against its
+                  sibling instances of the same role.
+                nullable: true
+                properties:
+                  spread:
+                    description: |-
+                      Topology spread rules applied to the Pods of this DNS server.
+
+                      Three distinct states:
+
+                      - **absent** — for a **primary** role with two or more servers, the
+                        operator applies its default: one soft (`ScheduleAnyway`) rule over
+                        `topology.kubernetes.io/zone` with `maxSkew: 1`. Secondaries and
+                        single-server roles get no constraint unless you ask for one.
+                      - **empty list** (`spread: []`) — explicitly no spread constraints.
+                        Use this to opt a multi-primary cluster out of the default.
+                      - **non-empty list** — exactly these rules, and no default. This is how
+                        secondaries opt *in*.
+
+                      At most 8 rules; each becomes one `topologySpreadConstraint`, and every
+                      constraint is re-evaluated on each scheduling attempt.
+                    items:
+                      description: |-
+                        A single topology spread rule.
+
+                        Each rule becomes exactly one entry in the Pod's
+                        `spec.topologySpreadConstraints`, with the `labelSelector` generated from
+                        [`SpreadScope`] rather than written by hand — users have no way to know the
+                        operator's internal Pod labels, and getting the selector wrong silently
+                        produces a constraint that does nothing.
+
+                        # Example
+
+                        ```yaml
+                        spread:
+                          # Spread primaries across zones first — hard requirement.
+                          - topologyKey: topology.kubernetes.io/zone
+                            maxSkew: 1
+                            whenUnsatisfiable: DoNotSchedule
+                            scope: Role
+                          # Then, within a zone, prefer separate nodes.
+                          - topologyKey: kubernetes.io/hostname
+                            maxSkew: 1
+                            whenUnsatisfiable: ScheduleAnyway
+                            scope: Role
+                        ```
+                      properties:
+                        maxSkew:
+                          description: |-
+                            Maximum permitted difference in Pod count between any two domains.
+
+                            Default: `1` (the tightest useful value — every domain is filled before
+                            any domain doubles up).
+                          format: int32
+                          maximum: 100.0
+                          minimum: 1.0
+                          nullable: true
+                          type: integer
+                        minDomains:
+                          description: |-
+                            Minimum number of domains that must be eligible.
+
+                            Only meaningful together with `whenUnsatisfiable: DoNotSchedule`. When
+                            fewer than `minDomains` domains exist, the constraint is treated as
+                            unsatisfiable. Use it to fail loudly rather than silently running all
+                            your nameservers in one zone.
+                          format: int32
+                          maximum: 1000.0
+                          minimum: 1.0
+                          nullable: true
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            Whether node affinity / taints are honoured when computing spread skew.
+
+                            Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                          enum:
+                          - Honor
+                          - Ignore
+                          nullable: true
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            Whether node affinity / taints are honoured when computing spread skew.
+
+                            Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                          enum:
+                          - Honor
+                          - Ignore
+                          nullable: true
+                          type: string
+                        scope:
+                          description: |-
+                            Which set of DNS Pods a spread rule balances across failure domains.
+
+                            This is the field that makes zone spreading actually work in Bindy, and it
+                            exists because a DNS server is not an anonymous replica.
+
+                            A `Bind9Cluster` with `primary.replicas: 3` does **not** create one
+                            three-Pod Deployment. Each primary is an individually addressable
+                            nameserver (its hostname ends up in an `NS` record), so the cluster
+                            controller creates three separate `Bind9Instance` resources, each backed by
+                            its own single-Pod Deployment. A spread constraint whose label selector
+                            matches only its own Deployment's Pods would therefore balance a set of
+                            size one — which is always trivially balanced, and spreads nothing.
+
+                            `scope` selects the label selector the operator generates, and so decides
+                            which Pods the scheduler counts per domain.
+                          enum:
+                          - Instance
+                          - Role
+                          - Cluster
+                          nullable: true
+                          type: string
+                        topologyKey:
+                          description: |-
+                            Node label key that defines the failure domain.
+
+                            Nodes sharing a value for this label are in the same domain. Any node
+                            label works, which is the point: clusters that do not use the
+                            well-known zone label can spread across whatever they do use.
+
+                            Examples:
+                            - `topology.kubernetes.io/zone` - availability zone (the usual choice)
+                            - `topology.kubernetes.io/region` - region, for multi-region clusters
+                            - `kubernetes.io/hostname` - individual nodes
+                            - `failure-domain.acme.io/rack` - a custom, on-prem failure domain
+                            - `karpenter.sh/capacity-type` - spot vs. on-demand capacity
+
+                            Must be a valid Kubernetes qualified name, matching what the API server
+                            accepts for a node label key: an optional lowercase RFC 1123 subdomain
+                            prefix of at most 253 characters, a `/`, and a name segment of at most
+                            63 characters. The maximum overall length is therefore 317.
+
+                            The 253-character prefix cap is enforced by an
+                            `x-kubernetes-validations` rule on the parent rule rather than by the
+                            pattern below: CRD patterns are RE2, which has no lookahead, so a
+                            length bound on a variable-length prefix cannot be expressed in the
+                            regex itself.
+                          maxLength: 317
+                          minLength: 1
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            How the scheduler should react when a spread rule cannot be satisfied.
+
+                            Mirrors Kubernetes `topologySpreadConstraints[].whenUnsatisfiable`.
+                          enum:
+                          - DoNotSchedule
+                          - ScheduleAnyway
+                          nullable: true
+                          type: string
+                      required:
+                      - topologyKey
+                      type: object
+                      x-kubernetes-validations:
+                      - message: 'minDomains is only valid together with whenUnsatisfiable: DoNotSchedule'
+                        rule: '!has(self.minDomains) || (has(self.whenUnsatisfiable) && self.whenUnsatisfiable == ''DoNotSchedule'')'
+                      - message: topologyKey prefix (the part before '/') must be at most 253 characters
+                        rule: self.topologyKey.indexOf('/') <= 253
+                    maxItems: 8
+                    nullable: true
+                    type: array
+                type: object
               primaryServers:
                 description: |-
                   Primary server addresses for zone transfers (required for secondary instances).

--- a/deploy/operator/crds/clusterbind9providers.crd.yaml
+++ b/deploy/operator/crds/clusterbind9providers.crd.yaml
@@ -991,6 +991,192 @@ spec:
                       by `DNSZone` resources using `bind9InstancesFrom.selector.matchLabels`.
                     nullable: true
                     type: object
+                  placement:
+                    description: |-
+                      Topology spreading for all primary instances in this cluster.
+
+                      This is the level most users want: it spreads every primary nameserver
+                      of the cluster across failure domains, which is exactly what protects
+                      against a zone outage taking out authoritative DNS.
+
+                      When unset, the operator applies a soft zone-spread default as soon as
+                      `primary.replicas` is 2 or more. Overridden per-server by
+                      `Bind9Instance.spec.placement`.
+
+                      # Example
+
+                      ```yaml
+                      primary:
+                        replicas: 3
+                        placement:
+                          spread:
+                            - topologyKey: topology.kubernetes.io/zone
+                              maxSkew: 1
+                              whenUnsatisfiable: DoNotSchedule
+                      ```
+                    nullable: true
+                    properties:
+                      spread:
+                        description: |-
+                          Topology spread rules applied to the Pods of this DNS server.
+
+                          Three distinct states:
+
+                          - **absent** — for a **primary** role with two or more servers, the
+                            operator applies its default: one soft (`ScheduleAnyway`) rule over
+                            `topology.kubernetes.io/zone` with `maxSkew: 1`. Secondaries and
+                            single-server roles get no constraint unless you ask for one.
+                          - **empty list** (`spread: []`) — explicitly no spread constraints.
+                            Use this to opt a multi-primary cluster out of the default.
+                          - **non-empty list** — exactly these rules, and no default. This is how
+                            secondaries opt *in*.
+
+                          At most 8 rules; each becomes one `topologySpreadConstraint`, and every
+                          constraint is re-evaluated on each scheduling attempt.
+                        items:
+                          description: |-
+                            A single topology spread rule.
+
+                            Each rule becomes exactly one entry in the Pod's
+                            `spec.topologySpreadConstraints`, with the `labelSelector` generated from
+                            [`SpreadScope`] rather than written by hand — users have no way to know the
+                            operator's internal Pod labels, and getting the selector wrong silently
+                            produces a constraint that does nothing.
+
+                            # Example
+
+                            ```yaml
+                            spread:
+                              # Spread primaries across zones first — hard requirement.
+                              - topologyKey: topology.kubernetes.io/zone
+                                maxSkew: 1
+                                whenUnsatisfiable: DoNotSchedule
+                                scope: Role
+                              # Then, within a zone, prefer separate nodes.
+                              - topologyKey: kubernetes.io/hostname
+                                maxSkew: 1
+                                whenUnsatisfiable: ScheduleAnyway
+                                scope: Role
+                            ```
+                          properties:
+                            maxSkew:
+                              description: |-
+                                Maximum permitted difference in Pod count between any two domains.
+
+                                Default: `1` (the tightest useful value — every domain is filled before
+                                any domain doubles up).
+                              format: int32
+                              maximum: 100.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            minDomains:
+                              description: |-
+                                Minimum number of domains that must be eligible.
+
+                                Only meaningful together with `whenUnsatisfiable: DoNotSchedule`. When
+                                fewer than `minDomains` domains exist, the constraint is treated as
+                                unsatisfiable. Use it to fail loudly rather than silently running all
+                                your nameservers in one zone.
+                              format: int32
+                              maximum: 1000.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            scope:
+                              description: |-
+                                Which set of DNS Pods a spread rule balances across failure domains.
+
+                                This is the field that makes zone spreading actually work in Bindy, and it
+                                exists because a DNS server is not an anonymous replica.
+
+                                A `Bind9Cluster` with `primary.replicas: 3` does **not** create one
+                                three-Pod Deployment. Each primary is an individually addressable
+                                nameserver (its hostname ends up in an `NS` record), so the cluster
+                                controller creates three separate `Bind9Instance` resources, each backed by
+                                its own single-Pod Deployment. A spread constraint whose label selector
+                                matches only its own Deployment's Pods would therefore balance a set of
+                                size one — which is always trivially balanced, and spreads nothing.
+
+                                `scope` selects the label selector the operator generates, and so decides
+                                which Pods the scheduler counts per domain.
+                              enum:
+                              - Instance
+                              - Role
+                              - Cluster
+                              nullable: true
+                              type: string
+                            topologyKey:
+                              description: |-
+                                Node label key that defines the failure domain.
+
+                                Nodes sharing a value for this label are in the same domain. Any node
+                                label works, which is the point: clusters that do not use the
+                                well-known zone label can spread across whatever they do use.
+
+                                Examples:
+                                - `topology.kubernetes.io/zone` - availability zone (the usual choice)
+                                - `topology.kubernetes.io/region` - region, for multi-region clusters
+                                - `kubernetes.io/hostname` - individual nodes
+                                - `failure-domain.acme.io/rack` - a custom, on-prem failure domain
+                                - `karpenter.sh/capacity-type` - spot vs. on-demand capacity
+
+                                Must be a valid Kubernetes qualified name, matching what the API server
+                                accepts for a node label key: an optional lowercase RFC 1123 subdomain
+                                prefix of at most 253 characters, a `/`, and a name segment of at most
+                                63 characters. The maximum overall length is therefore 317.
+
+                                The 253-character prefix cap is enforced by an
+                                `x-kubernetes-validations` rule on the parent rule rather than by the
+                                pattern below: CRD patterns are RE2, which has no lookahead, so a
+                                length bound on a variable-length prefix cannot be expressed in the
+                                regex itself.
+                              maxLength: 317
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                How the scheduler should react when a spread rule cannot be satisfied.
+
+                                Mirrors Kubernetes `topologySpreadConstraints[].whenUnsatisfiable`.
+                              enum:
+                              - DoNotSchedule
+                              - ScheduleAnyway
+                              nullable: true
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                          x-kubernetes-validations:
+                          - message: 'minDomains is only valid together with whenUnsatisfiable: DoNotSchedule'
+                            rule: '!has(self.minDomains) || (has(self.whenUnsatisfiable) && self.whenUnsatisfiable == ''DoNotSchedule'')'
+                          - message: topologyKey prefix (the part before '/') must be at most 253 characters
+                            rule: self.topologyKey.indexOf('/') <= 253
+                        maxItems: 8
+                        nullable: true
+                        type: array
+                    type: object
                   replicas:
                     description: |-
                       Number of primary instance replicas (default: 1)
@@ -1603,6 +1789,193 @@ spec:
                       These labels will appear on the `Bind9Instance` metadata and can be referenced
                       by `DNSZone` resources using `bind9InstancesFrom.selector.matchLabels`.
                     nullable: true
+                    type: object
+                  placement:
+                    description: |-
+                      Topology spreading for all secondary instances in this cluster.
+
+                      **No default applies here.** The operator's automatic zone spread is
+                      limited to primaries, which is what issue #467 asked for and what a
+                      zone outage most threatens: primaries are authoritative and, unlike
+                      secondaries, cannot be re-created from another server's data. Silently
+                      changing where existing secondary workloads schedule would be an
+                      unannounced policy change on a running cluster.
+
+                      Secondaries therefore opt in explicitly:
+
+                      ```yaml
+                      secondary:
+                        replicas: 3
+                        placement:
+                          spread:
+                            - topologyKey: topology.kubernetes.io/zone
+                              maxSkew: 1
+                              whenUnsatisfiable: ScheduleAnyway
+                      ```
+
+                      See `PrimaryConfig.placement` for field documentation.
+                    nullable: true
+                    properties:
+                      spread:
+                        description: |-
+                          Topology spread rules applied to the Pods of this DNS server.
+
+                          Three distinct states:
+
+                          - **absent** — for a **primary** role with two or more servers, the
+                            operator applies its default: one soft (`ScheduleAnyway`) rule over
+                            `topology.kubernetes.io/zone` with `maxSkew: 1`. Secondaries and
+                            single-server roles get no constraint unless you ask for one.
+                          - **empty list** (`spread: []`) — explicitly no spread constraints.
+                            Use this to opt a multi-primary cluster out of the default.
+                          - **non-empty list** — exactly these rules, and no default. This is how
+                            secondaries opt *in*.
+
+                          At most 8 rules; each becomes one `topologySpreadConstraint`, and every
+                          constraint is re-evaluated on each scheduling attempt.
+                        items:
+                          description: |-
+                            A single topology spread rule.
+
+                            Each rule becomes exactly one entry in the Pod's
+                            `spec.topologySpreadConstraints`, with the `labelSelector` generated from
+                            [`SpreadScope`] rather than written by hand — users have no way to know the
+                            operator's internal Pod labels, and getting the selector wrong silently
+                            produces a constraint that does nothing.
+
+                            # Example
+
+                            ```yaml
+                            spread:
+                              # Spread primaries across zones first — hard requirement.
+                              - topologyKey: topology.kubernetes.io/zone
+                                maxSkew: 1
+                                whenUnsatisfiable: DoNotSchedule
+                                scope: Role
+                              # Then, within a zone, prefer separate nodes.
+                              - topologyKey: kubernetes.io/hostname
+                                maxSkew: 1
+                                whenUnsatisfiable: ScheduleAnyway
+                                scope: Role
+                            ```
+                          properties:
+                            maxSkew:
+                              description: |-
+                                Maximum permitted difference in Pod count between any two domains.
+
+                                Default: `1` (the tightest useful value — every domain is filled before
+                                any domain doubles up).
+                              format: int32
+                              maximum: 100.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            minDomains:
+                              description: |-
+                                Minimum number of domains that must be eligible.
+
+                                Only meaningful together with `whenUnsatisfiable: DoNotSchedule`. When
+                                fewer than `minDomains` domains exist, the constraint is treated as
+                                unsatisfiable. Use it to fail loudly rather than silently running all
+                                your nameservers in one zone.
+                              format: int32
+                              maximum: 1000.0
+                              minimum: 1.0
+                              nullable: true
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                Whether node affinity / taints are honoured when computing spread skew.
+
+                                Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+                              enum:
+                              - Honor
+                              - Ignore
+                              nullable: true
+                              type: string
+                            scope:
+                              description: |-
+                                Which set of DNS Pods a spread rule balances across failure domains.
+
+                                This is the field that makes zone spreading actually work in Bindy, and it
+                                exists because a DNS server is not an anonymous replica.
+
+                                A `Bind9Cluster` with `primary.replicas: 3` does **not** create one
+                                three-Pod Deployment. Each primary is an individually addressable
+                                nameserver (its hostname ends up in an `NS` record), so the cluster
+                                controller creates three separate `Bind9Instance` resources, each backed by
+                                its own single-Pod Deployment. A spread constraint whose label selector
+                                matches only its own Deployment's Pods would therefore balance a set of
+                                size one — which is always trivially balanced, and spreads nothing.
+
+                                `scope` selects the label selector the operator generates, and so decides
+                                which Pods the scheduler counts per domain.
+                              enum:
+                              - Instance
+                              - Role
+                              - Cluster
+                              nullable: true
+                              type: string
+                            topologyKey:
+                              description: |-
+                                Node label key that defines the failure domain.
+
+                                Nodes sharing a value for this label are in the same domain. Any node
+                                label works, which is the point: clusters that do not use the
+                                well-known zone label can spread across whatever they do use.
+
+                                Examples:
+                                - `topology.kubernetes.io/zone` - availability zone (the usual choice)
+                                - `topology.kubernetes.io/region` - region, for multi-region clusters
+                                - `kubernetes.io/hostname` - individual nodes
+                                - `failure-domain.acme.io/rack` - a custom, on-prem failure domain
+                                - `karpenter.sh/capacity-type` - spot vs. on-demand capacity
+
+                                Must be a valid Kubernetes qualified name, matching what the API server
+                                accepts for a node label key: an optional lowercase RFC 1123 subdomain
+                                prefix of at most 253 characters, a `/`, and a name segment of at most
+                                63 characters. The maximum overall length is therefore 317.
+
+                                The 253-character prefix cap is enforced by an
+                                `x-kubernetes-validations` rule on the parent rule rather than by the
+                                pattern below: CRD patterns are RE2, which has no lookahead, so a
+                                length bound on a variable-length prefix cannot be expressed in the
+                                regex itself.
+                              maxLength: 317
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                How the scheduler should react when a spread rule cannot be satisfied.
+
+                                Mirrors Kubernetes `topologySpreadConstraints[].whenUnsatisfiable`.
+                              enum:
+                              - DoNotSchedule
+                              - ScheduleAnyway
+                              nullable: true
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                          x-kubernetes-validations:
+                          - message: 'minDomains is only valid together with whenUnsatisfiable: DoNotSchedule'
+                            rule: '!has(self.minDomains) || (has(self.whenUnsatisfiable) && self.whenUnsatisfiable == ''DoNotSchedule'')'
+                          - message: topologyKey prefix (the part before '/') must be at most 253 characters
+                            rule: self.topologyKey.indexOf('/') <= 253
+                        maxItems: 8
+                        nullable: true
+                        type: array
                     type: object
                   replicas:
                     description: |-

--- a/docs/adr/0003-pod-placement-and-zone-spreading.md
+++ b/docs/adr/0003-pod-placement-and-zone-spreading.md
@@ -1,0 +1,269 @@
+# ADR-0003: Pod Placement and Zone Spreading
+
+## Status
+
+Accepted
+
+## Context
+
+The Deployments the operator builds (`build_deployment` in
+`src/bind9_resources.rs`) set no scheduling constraints at all — no
+`affinity`, no `nodeSelector`, no `topologySpreadConstraints`. On a multi-zone
+cluster the scheduler is therefore free to place every primary DNS Pod in a
+single zone. A zone outage then takes out all authoritative DNS at once,
+defeating the point of running multiple primaries. This is issue #467.
+
+### The complication: a DNS server is not an anonymous replica
+
+The obvious fix — one `topologySpreadConstraint` on the pod template — does
+not work here, because of how Bindy models nameservers.
+
+A zone's `NS` records name the *individual* servers authoritative for it, and
+resolvers query those names directly. Each nameserver therefore needs a stable
+identity and its own address. Bindy gives every server its own
+`Bind9Instance`, Deployment, Service, and RNDC key, and
+`create_managed_instance_with_owner`
+(`src/reconcilers/bind9cluster/instances.rs`) hardcodes `replicas: 1` on each
+generated instance.
+
+So `Bind9Cluster.spec.primary.replicas: 3` produces **three single-Pod
+Deployments**, not one three-Pod Deployment.
+
+A `topologySpreadConstraint` balances the set of Pods matched by its
+`labelSelector`, bucketed by `topologyKey`. A selector matching only the local
+Deployment's Pods would describe a set of size one — always trivially balanced
+— so the constraint would be satisfied by any placement and all three
+primaries could still land in one zone. The constraint would appear to work
+and do nothing.
+
+Two further constraints shaped the design:
+
+- **`spec.selector` is immutable.** The label set built by
+  `build_labels_from_instance` fed both the Deployment's `spec.selector` and
+  its pod template. Any new label added there would change the selector, which
+  Kubernetes rejects, wedging the reconciler on every Deployment that already
+  exists.
+- **The update path was an allow-list.** `deployment_needs_update`
+  (`src/reconcilers/bind9instance/resources.rs`) compared only replicas and
+  the bindcar container, and the strategic-merge patch below it sent only
+  those fields. Any new pod-spec field would have been written once at
+  creation and never reconciled again.
+
+## Decision
+
+### 1. A `placement.spread` API, scoped to topology spreading only
+
+```yaml
+placement:
+  spread:
+    - topologyKey: topology.kubernetes.io/zone
+      maxSkew: 1
+      whenUnsatisfiable: DoNotSchedule
+      minDomains: 3
+      scope: Role
+```
+
+Settable at two levels, resolved whole-block, most specific first:
+
+1. `Bind9Instance.spec.placement`
+2. `spec.primary.placement` / `spec.secondary.placement`
+
+Resolution is whole-block rather than field-by-field so that "what will
+actually be scheduled" is answerable by reading one block. A silently
+half-inherited scheduling rule is a bad failure mode: a Pod in the wrong place
+is invisible until the outage it was supposed to prevent.
+
+### 2. `scope` generates the label selector
+
+`scope` is the field that makes spreading work at all:
+
+| Scope | Generated selector | Balanced set |
+|---|---|---|
+| `Role` (default, cluster-managed) | `bindy.firestoned.io/cluster` + `role` | all primaries of the cluster |
+| `Cluster` | `bindy.firestoned.io/cluster` | every DNS Pod of the cluster |
+| `Instance` (default, standalone) | the Deployment's own labels | that instance's replicas |
+
+Users never write the selector themselves. It depends on the operator's
+internal pod labels, which are not part of the public contract, and a wrong
+selector fails silently rather than loudly.
+
+This required adding `bindy.firestoned.io/cluster` to the pod labels. Because
+`spec.selector` is immutable, the single label map was split in two:
+`build_labels_from_instance` stays frozen and owns the selector;
+`build_pod_labels_from_instance` is a superset applied to the pod template
+only. Kubernetes requires the selector to *match* the template, not to equal
+it, so a template may carry extra labels.
+
+### 3. The default applies to primaries only, and is soft
+
+With no `placement` anywhere, a primary role with two or more servers gets one
+`ScheduleAnyway`, `maxSkew: 1` constraint over
+`topology.kubernetes.io/zone`. Secondaries and single-server roles get
+nothing.
+
+**Soft, not hard**: a hard default turns a single-zone cluster — or the zone
+outage this feature exists to guard against — into `Pending` DNS Pods, trading
+degraded availability for a total outage.
+
+**Primaries only** for two reasons. A primary is authoritative and holds the
+writable copy of a zone; a secondary can be rebuilt from a primary at any
+time, so losing every primary to one zone is the failure that matters. And
+defaulting secondaries would silently change where already-running secondary
+Pods are scheduled the moment an operator is upgraded — an unannounced
+scheduling policy change on a live cluster. Secondaries opt in explicitly via
+`secondary.placement.spread`.
+
+### 4. No `nodeSelector`, `tolerations`, or `affinity` passthrough
+
+An earlier revision of this work accepted the full Kubernetes `Affinity`,
+`Toleration`, and node-selector types at four API levels, as an escape hatch.
+That was reverted. See Consequences.
+
+### 5. Validation is structural where it can be
+
+The generated CRD schema carries `maxItems: 8` on `spread`, a label-key
+`pattern` on `topologyKey`, `minimum`/`maximum` on the numeric fields, enums
+on `scope` / `whenUnsatisfiable` / the node policies, and an
+`x-kubernetes-validations` CEL rule for the `minDomains` ⇒ `DoNotSchedule`
+pairing. All of it is emitted from `src/crd.rs` via `schemars`, so it needs no
+hand-editing of generated YAML and no optional admission policy to be
+enforced.
+
+`src/placement.rs::validate_placement` remains as a reconcile-time backstop
+for clusters running an older CRD revision, and covers the one rule a
+structural schema cannot express cheaply: uniqueness of
+`(topologyKey, whenUnsatisfiable)` across rules.
+
+#### `topologyKey` limits, measured rather than assumed
+
+`topologyKey` must be a valid Kubernetes qualified name. The exact bounds were
+verified against a live API server rather than inferred, because two of them
+are easy to get wrong:
+
+- **The maximum length is 317, not 316.** A qualified name is a prefix of up to
+  253 characters, a `/`, and a name of up to 63 — so a maximal key is 317
+  characters and is accepted. An earlier revision capped at 316 and rejected it.
+- **There is no 63-character cap on an individual DNS label.** RFC 1123 caps a
+  DNS label at 63 octets, but Kubernetes' `IsDNS1123Subdomain` bounds only the
+  253-character total and the charset. A key such as `<64 a's>/zone` is
+  accepted by the API server both as a node label and as a `topologyKey`.
+  Bindy therefore does not reject it: refusing input the platform accepts would
+  be a worse failure than mirroring the platform's own looseness.
+- **The 253-character prefix cap is enforced by CEL, not by the pattern.** CRD
+  `pattern` is RE2, which has no lookahead, so a length bound on a
+  variable-length prefix cannot be expressed in the regex. The rule
+  `self.topologyKey.indexOf('/') <= 253` covers it (`indexOf` returns the
+  prefix length, or `-1` when there is no prefix).
+
+The generated schema is itself asserted by unit tests
+(`generated_schema_*` in `src/placement_tests.rs`), so dropping a `#[schemars]`
+attribute fails CI rather than silently moving enforcement from admission time
+to reconcile time.
+
+### 6. Cluster-level config is resolved live, and instances are woken by a watch
+
+Role-level `placement` is resolved against the live cluster object when the
+Deployment is built, rather than copied down into every managed
+`Bind9Instance` spec. That avoids rewriting N instance specs on every
+cluster-level edit, but means an instance is not otherwise notified. The
+`Bind9Instance` controller therefore watches `Bind9Cluster` and
+`ClusterBind9Provider` (`src/main.rs`), mapping a cluster event to its
+instances. Measured propagation went from ~240s (the 5-minute requeue) to
+sub-second.
+
+## Alternatives considered
+
+### `spec.spreadAcrossZones: true`
+
+Suggested in issue #467. Rejected: a boolean cannot express a custom topology
+key (clusters that do not label nodes with `topology.kubernetes.io/zone`),
+soft versus hard, `minDomains`, or — decisively — the scope question, which is
+the difference between a working constraint and a no-op.
+
+### Pod anti-affinity instead of topology spread
+
+`preferredDuringSchedulingIgnoredDuringExecution` keyed on zone. Rejected:
+anti-affinity can only express "not together", which stops being useful as
+soon as there are more replicas than domains. Topology spread degrades
+gracefully, supports `maxSkew` and `minDomains`, and is the modern, cheaper
+scheduler plugin.
+
+### Full pod-spec passthrough (`affinity` / `tolerations` / `nodeSelector`)
+
+Implemented first, then removed on review. Rejected on three grounds:
+
+- **CRD size.** The embedded Kubernetes schemas added ~451KB across the three
+  cluster CRDs (`bind9clusters` 275KB → 469KB). Removing them brings the
+  feature's total cost to ~48KB.
+- **Security surface.** Those three fields are exactly the primitives a
+  namespace tenant needs to schedule a Pod carrying operator-issued
+  credentials onto a control-plane node. Accepting them required an
+  allow-list validator plus a `ValidatingAdmissionPolicy` mirroring it —
+  mitigating a threat model that simply does not exist if the fields are not
+  accepted. Not accepting them deletes the problem instead of guarding it.
+- **Scope.** Issue #467 asked for zone spreading. Node tiering is a separate
+  request that deserves its own design, and can be added later as a small
+  typed API without re-litigating this one.
+
+Users who genuinely need raw affinity or tolerations today can set them on the
+generated Deployment out-of-band, or open an issue describing the case.
+
+### Unstructured passthrough (`x-kubernetes-preserve-unknown-fields`)
+
+Would have kept the escape hatch at near-zero CRD cost. Rejected: it
+sacrifices all schema validation and `kubectl explain`, and does nothing about
+the control-plane security surface, which was the more serious of the two
+problems.
+
+## Consequences
+
+### Positive
+
+- Multi-primary clusters spread across zones by default, with no
+  configuration.
+- Any node label works as a failure domain, so on-prem clusters can spread
+  across racks or cells.
+- The feature costs ~48KB of CRD schema and adds no admission policy.
+- No new privilege-escalation surface: `placement` cannot influence *which*
+  nodes are eligible, only how Pods are balanced across the ones that already
+  are.
+- Bad input is rejected at admission by the API server, not discovered several
+  reconciles later.
+
+### Negative
+
+- The three cluster CRDs grow by ~19KB each. They already exceeded the 256KB
+  `last-applied-configuration` annotation limit on `main` (275KB), so
+  client-side `kubectl apply` was already failing; installation docs, the
+  `crdgen` output, and the combined `crds.yaml` header now state
+  `--server-side` explicitly.
+- Adding the `bindy.firestoned.io/cluster` pod label changes the pod template
+  hash, so every DNS Pod restarts once on the upgrade that introduces it.
+  Restarts are staggered across instances, so a zone stays served, but this
+  belongs in release notes. There is still no PodDisruptionBudget in the repo
+  (tracked separately).
+- `scope` is a Bindy-specific concept users must learn. It is documented in
+  `docs/src/guide/zone-spreading.md`, and the default is correct for both the
+  cluster-managed and standalone shapes, so most users never set it.
+- Node tiering (`nodeSelector` / `tolerations`) is not available through the
+  CRD. This is a deliberate deferral, not an oversight.
+
+## Verification
+
+`tests/zone_spread_test.sh` runs against the three-zone kind cluster defined in
+`deploy/kind-config-multizone.yaml`. The load-bearing assertion is not "Pods
+landed in different zones" — the scheduler's default scoring often achieves
+that on its own, so a passing spread proves nothing. It asserts instead that
+the generated selector matches all sibling primaries, that `spec.selector`
+stays free of the cluster label, that placement changes (including removals)
+converge onto existing Deployments, that Deployments predating the feature are
+repaired in place, and — decisively — that with two of three zones cordoned
+the extra primaries go `Pending` citing topology spread constraints. That last
+check can only pass if the cross-instance selector is correct.
+
+## References
+
+- Issue [#467](https://github.com/firestoned/bindy/issues/467)
+- `src/placement.rs`, `src/crd.rs` (`PlacementConfig`, `SpreadRule`, `SpreadScope`)
+- `docs/src/guide/zone-spreading.md`
+- [Kubernetes: Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -219,6 +219,7 @@ nav:
           - Primary Instances: guide/primary-instance.md
           - Secondary Instances: guide/secondary-instance.md
           - Multi-Region: guide/multi-region.md
+          - Zone Spreading & Placement: guide/zone-spreading.md
       - Managing Zones:
           - Overview: guide/zones.md
           - Creating Zones: guide/creating-zones.md

--- a/docs/src/compliance/crypto-audit.md
+++ b/docs/src/compliance/crypto-audit.md
@@ -117,7 +117,7 @@ let secret = Secret {
 
 **Evidence:**
 - [src/bind9_resources.rs](https://github.com/firestoned/bindy/blob/main/src/bind9_resources.rs) - Secret generation
-- [deploy/crds/bind9instances.crd.yaml](../../deploy/crds/bind9instances.crd.yaml) - TSIG configuration
+- [deploy/operator/crds/bind9instances.crd.yaml](../../deploy/operator/crds/bind9instances.crd.yaml) - TSIG configuration
 
 ---
 

--- a/docs/src/compliance/nist-800-53.md
+++ b/docs/src/compliance/nist-800-53.md
@@ -173,7 +173,7 @@ Verbs: get, list, watch, create, update, patch, delete
 - **Infrastructure as Code:** All configuration in Git-versioned manifests
 - **CRD Schemas:** Define allowed configuration via OpenAPI v3 schemas
 - **Default Values:** Sensible defaults documented in CRD API reference
-- **Evidence:** [deploy/crds/](../../deploy/crds/), [docs/src/reference/api.md](../reference/api.md)
+- **Evidence:** [deploy/operator/crds/](../../deploy/operator/crds/), [docs/src/reference/api.md](../reference/api.md)
 
 **Status:** ✅ Implemented
 

--- a/docs/src/compliance/sox-controls.md
+++ b/docs/src/compliance/sox-controls.md
@@ -113,7 +113,7 @@ Bindy is designed for use in regulated banking environments where DNS infrastruc
 
 #### DI-1: Declarative Configuration
 - **Control:** Infrastructure as Code prevents configuration drift
-- **Evidence:** CRD schemas in `deploy/crds/`
+- **Evidence:** CRD schemas in `deploy/operator/crds/`
 - **Implementation:**
   - All DNS configuration in CustomResources
   - Schema validation via OpenAPI v3

--- a/docs/src/development/testing-guide.md
+++ b/docs/src/development/testing-guide.md
@@ -313,7 +313,7 @@ kubectl logs -n bindy-system -l app=bindy
 kubectl get crds | grep bindy.firestoned.io
 
 # Install
-kubectl apply -k deploy/crds
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
 **Resource creation fails**

--- a/docs/src/development/workflow.md
+++ b/docs/src/development/workflow.md
@@ -33,7 +33,7 @@ cargo fmt
 5. **Validate CRDs**
 ```bash
 # Ensure generated CRDs are valid
-kubectl apply --dry-run=client -f deploy/crds/
+kubectl apply --dry-run=server -f deploy/operator/crds/
 ```
 
 6. **Commit changes**
@@ -50,7 +50,7 @@ git push origin feature/my-feature
 
 ## CRD Development
 
-**IMPORTANT:** `src/crd.rs` is the source of truth. CRD YAML files in `deploy/crds/` are auto-generated.
+**IMPORTANT:** `src/crd.rs` is the source of truth. CRD YAML files in `deploy/operator/crds/` are auto-generated.
 
 ### Modifying Existing CRDs
 
@@ -81,10 +81,10 @@ make crds
 3. **Verify the generated YAML**:
 ```bash
 # Check the generated file
-cat deploy/crds/bind9clusters.crd.yaml
+cat deploy/operator/crds/bind9clusters.crd.yaml
 
 # Validate it
-kubectl apply --dry-run=client -f deploy/crds/bind9clusters.crd.yaml
+kubectl apply --dry-run=server -f deploy/operator/crds/bind9clusters.crd.yaml
 ```
 
 4. **Update documentation** to describe the new field
@@ -116,7 +116,7 @@ kind create cluster --name bindy-dev
 
 # Deploy CRDs (regenerate first if modified)
 make crds
-kubectl apply -k deploy/crds/
+kubectl apply --server-side -f deploy/operator/crds/
 
 # Run operator locally
 RUST_LOG=debug cargo run

--- a/docs/src/guide/multi-region.md
+++ b/docs/src/guide/multi-region.md
@@ -2,6 +2,15 @@
 
 Distribute your DNS infrastructure across multiple regions or availability zones for maximum availability and performance.
 
+!!! tip "Spreading within one cluster"
+    This page covers running *separate* instances per region, each with its own
+    identity and address. If instead you have one Kubernetes cluster spanning
+    several availability zones and want the operator to distribute nameservers
+    across them automatically, see
+    [Zone Spreading and Pod Placement](zone-spreading.md) — that is handled by
+    `spec.placement`, and a soft zone spread is applied by default whenever a
+    role has two or more servers.
+
 ## Architecture Overview
 
 A multi-region DNS setup typically includes:

--- a/docs/src/guide/rndc-key-rotation.md
+++ b/docs/src/guide/rndc-key-rotation.md
@@ -450,7 +450,7 @@ kubectl logs -n bindy-system -l app.kubernetes.io/name=bindy-operator | grep "Tr
 2. **Regenerate and apply CRDs if needed**:
    ```bash
    cargo run --bin crdgen
-   kubectl replace --force -f deploy/crds/bind9instances.crd.yaml
+   kubectl apply --server-side -f deploy/operator/crds/bind9instances.crd.yaml
    ```
 
 ---

--- a/docs/src/guide/zone-spreading.md
+++ b/docs/src/guide/zone-spreading.md
@@ -1,0 +1,312 @@
+# Zone Spreading and Pod Placement
+
+Distribute DNS servers across availability zones — or racks, or any other
+failure domain your cluster labels nodes with — so a single domain outage
+cannot take out every nameserver at once.
+
+## Why this needs its own feature
+
+In most Kubernetes workloads, `replicas: 3` means one Deployment with three
+interchangeable Pods behind one Service. Spreading them is a one-line
+`topologySpreadConstraint`.
+
+DNS does not work that way. A zone's `NS` records name the *individual*
+servers authoritative for it, and resolvers query those names directly. Each
+nameserver therefore needs a stable identity and its own address. Bindy models
+that by giving every server its own `Bind9Instance`, its own Deployment, its
+own Service, and its own RNDC key.
+
+So a cluster like this:
+
+```yaml
+spec:
+  primary:
+    replicas: 3
+```
+
+creates **three `Bind9Instance` resources, each backed by a single-Pod
+Deployment** — not one three-Pod Deployment.
+
+That distinction is the whole problem. A `topologySpreadConstraint` balances
+the set of Pods matched by its `labelSelector`, bucketed by the value of
+`topologyKey` on their node. If the constraint selected only its own
+Deployment's Pods, the set would have exactly one member — always trivially
+balanced — so the constraint would be satisfied by *any* placement and all
+three primaries could still land in the same zone.
+
+Bindy solves this with [`scope`](#scope), which generates a selector matching
+the sibling instances rather than just the local Deployment. You never write
+that selector yourself: it depends on the operator's internal Pod labels, and
+getting it wrong fails silently rather than loudly.
+
+## The default
+
+**You usually need no configuration at all.** With two or more **primaries**,
+the operator applies a soft zone spread on its own:
+
+```yaml
+topologySpreadConstraints:
+  - topologyKey: topology.kubernetes.io/zone
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        bindy.firestoned.io/cluster: my-dns
+        bindy.firestoned.io/role: primary
+```
+
+A single-primary cluster gets no constraint, because balancing one Pod is a
+no-op.
+
+The default is deliberately **soft** (`ScheduleAnyway`). A hard constraint on a
+single-zone cluster — or during the very zone outage this feature guards
+against — leaves DNS Pods `Pending`, trading degraded availability for a total
+outage. The scheduler still fills zones evenly whenever it can.
+
+### Secondaries have no default
+
+The automatic spread covers primaries only. A primary is authoritative and
+holds the writable copy of a zone; a secondary can be rebuilt from a primary at
+any time, so losing every primary to one zone outage is the failure that
+matters. Just as importantly, defaulting secondaries would silently change
+where already-running secondary Pods are scheduled the moment you upgrade the
+operator, which is not a decision an operator should make on your behalf.
+
+Secondaries opt in explicitly:
+
+```yaml
+spec:
+  secondary:
+    replicas: 3
+    placement:
+      spread:
+        - topologyKey: topology.kubernetes.io/zone
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+```
+
+## Configuring placement
+
+`placement` can be set at two levels:
+
+| Level | Field | Applies to |
+|---|---|---|
+| Instance | `Bind9Instance.spec.placement` | one DNS server |
+| Role | `spec.primary.placement`, `spec.secondary.placement` on `Bind9Cluster` / `ClusterBind9Provider` | every server of that role |
+
+Resolution is **whole-block**: the more specific level wins outright, and the
+other is not merged into it. That keeps "what will actually be scheduled"
+answerable by reading one block instead of mentally combining two —
+half-inherited scheduling rules are a bad failure mode, because a Pod in the
+wrong place is invisible until the outage.
+
+### Spread rules
+
+```yaml
+spec:
+  primary:
+    replicas: 3
+    placement:
+      spread:
+        - topologyKey: topology.kubernetes.io/zone
+          maxSkew: 1
+          whenUnsatisfiable: DoNotSchedule
+          minDomains: 3
+          scope: Role
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `topologyKey` | *(required)* | Node label defining the failure domain. A Kubernetes qualified name: optional ≤253-char prefix, `/`, ≤63-char name — 317 overall |
+| `maxSkew` | `1` | Largest permitted Pod-count difference between domains (1–100) |
+| `whenUnsatisfiable` | `ScheduleAnyway` | `DoNotSchedule` for a hard guarantee |
+| `scope` | `Role` (cluster-managed) / `Instance` (standalone) | Which Pods are balanced |
+| `minDomains` | unset | Fail if fewer domains exist (1–1000). Requires `DoNotSchedule` |
+| `nodeAffinityPolicy` | `Honor` | Count only nodes this Pod could land on |
+| `nodeTaintsPolicy` | `Ignore` | Whether node taints exclude nodes from counting |
+
+Each rule becomes one `topologySpreadConstraint`; at most 8 per Pod.
+
+Three states, and the difference matters:
+
+- **`spread` absent** — the operator applies its default (primaries only).
+- **`spread: []`** — explicitly no constraints. This is the opt-out.
+- **`spread: [...]`** — exactly these rules, and no default. This is also how
+  secondaries opt in.
+
+`spread` accepts at most 8 rules; the CRD schema rejects more at admission.
+
+### `topologyKey` — any node label works
+
+This is the answer to "our cluster doesn't use `topology.kubernetes.io/zone`."
+Any node label is a valid failure domain:
+
+```yaml
+spread:
+  # On-prem: the real failure domain is the rack.
+  - topologyKey: failure-domain.acme.io/rack
+    maxSkew: 1
+    whenUnsatisfiable: DoNotSchedule
+  # Then prefer separate hosts within a rack.
+  - topologyKey: kubernetes.io/hostname
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+```
+
+Other useful keys: `topology.kubernetes.io/region` for multi-region clusters,
+`karpenter.sh/capacity-type` to balance spot against on-demand capacity.
+
+### `scope`
+
+Decides which Pods the scheduler counts per domain.
+
+| Scope | Selector | Use when |
+|---|---|---|
+| `Role` | `cluster` + `role` | **Default for cluster-managed instances.** All primaries of the cluster balance against each other |
+| `Cluster` | `cluster` | Total DNS footprint per zone matters more than per-role balance. Set it on both role blocks so every Pod carries it |
+| `Instance` | the Deployment's own labels | **Default for a standalone `Bind9Instance`** with `replicas > 1` |
+
+`Role` and `Cluster` need an owning cluster — a standalone instance's Pods
+carry no cluster label — so they fall back to `Instance` with a warning.
+
+### What `placement` deliberately does not cover
+
+`placement` accepts topology spreading and nothing else. There is no
+`nodeSelector`, `tolerations`, or `affinity` passthrough.
+
+Two reasons. Embedding the full Kubernetes `Affinity` and `Toleration` schemas
+added roughly 450KB to the generated CRDs — more than the rest of the API
+combined. And those three fields are precisely the primitives needed to
+schedule a Pod onto a control-plane node; since DNS Pods carry operator-issued
+credentials, accepting them would have meant shipping an allow-list validator
+and an admission policy to guard a risk that simply does not exist if the
+fields are not accepted.
+
+`placement` therefore cannot influence *which* nodes are eligible for a DNS
+Pod, only how Pods are balanced across the ones that already are. See
+[ADR-0003](https://github.com/firestoned/bindy/blob/main/docs/adr/0003-pod-placement-and-zone-spreading.md).
+
+If you need DNS pinned to a particular node pool today, set `nodeSelector` or
+`tolerations` on the generated Deployment out-of-band, or open an issue
+describing the case — a small typed API for node tiering can be added without
+re-opening this design.
+
+## Validation
+
+Most invalid input is rejected by the API server at admission, from the CRD
+schema itself — no optional admission policy required:
+
+| Rule | Enforced by |
+|---|---|
+| at most 8 spread rules | `maxItems` |
+| `topologyKey` is a valid label key, 1–317 chars | `pattern`, `minLength`, `maxLength` |
+| `topologyKey` prefix (before `/`) ≤ 253 chars | `x-kubernetes-validations` (CEL) |
+| `maxSkew` between 1 and 100 | `minimum` / `maximum` |
+| `minDomains` between 1 and 1000 | `minimum` / `maximum` |
+| `scope`, `whenUnsatisfiable`, node policies | `enum` |
+| `minDomains` only with `whenUnsatisfiable: DoNotSchedule` | `x-kubernetes-validations` (CEL) |
+
+For example:
+
+```console
+$ kubectl apply -f bad.yaml
+The Bind9Cluster "my-dns" is invalid: spec.primary.placement.spread[0]:
+Invalid value: "object": minDomains is only valid together with
+whenUnsatisfiable: DoNotSchedule
+```
+
+The reconciler re-validates as a backstop — for clusters still running an older
+CRD revision — and additionally rejects two rules sharing the same
+`(topologyKey, whenUnsatisfiable)` pair, which Kubernetes requires to be unique
+and which a structural schema cannot express cheaply. Those surface as a
+`Ready=False` condition naming the offending field.
+
+## Verifying it works
+
+The trap here is that a passing spread proves nothing on its own: the
+scheduler's default scoring often distributes Pods anyway. Check the
+**selector**, not the outcome.
+
+```console
+$ kubectl get deploy my-dns-primary-0 \
+    -o jsonpath='{.spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels}'
+{"bindy.firestoned.io/cluster":"my-dns","bindy.firestoned.io/role":"primary"}
+```
+
+If that selector names only the instance (`app.kubernetes.io/instance`), it is
+balancing a set of one and doing nothing. Confirm the set is the size you
+expect:
+
+```console
+$ kubectl get pods -l bindy.firestoned.io/cluster=my-dns,bindy.firestoned.io/role=primary
+NAME                                  READY   STATUS    RESTARTS   AGE
+my-dns-primary-0-6955f99d86-8pp67     2/2     Running   0          3m
+my-dns-primary-1-5db9449df9-8z5lx     2/2     Running   0          3m
+my-dns-primary-2-77cd7f747b-6skcf     2/2     Running   0          3m
+```
+
+And which zones they occupy:
+
+```console
+$ kubectl get pods -l bindy.firestoned.io/cluster=my-dns -o wide
+```
+
+For a full local verification — including proving a hard constraint is really
+enforced — see [Testing on a multi-zone cluster](#testing-on-a-multi-zone-cluster).
+
+## Testing on a multi-zone cluster
+
+kind nodes are containers on one host, so there are no real failure domains.
+That does not matter: the scheduler buckets nodes purely by node label, so
+labelling three workers reproduces multi-zone scheduling exactly.
+
+```bash
+kind create cluster --config deploy/kind-config-multizone.yaml
+kubectl apply --server-side -f deploy/operator/crds/
+kubectl create namespace bindy-system
+kubectl apply -f deploy/operator/rbac/
+# Run the operator (in-cluster, or locally against the kind context)
+POD_NAMESPACE=bindy-system BINDY_ENABLE_LEADER_ELECTION=false cargo run -- run
+
+# In another shell:
+./tests/zone_spread_test.sh
+```
+
+The script asserts the selector spans siblings, that `spec.selector` stays
+free of the cluster label, that placement changes converge onto existing
+Deployments, and — the decisive one — that with two of three zones cordoned
+the extra primaries go `Pending` citing topology spread constraints. That last
+check can only pass if the cross-instance selector is correct.
+
+## Troubleshooting
+
+**Pods are `Pending` with `didn't match pod topology spread constraints`.**
+A hard constraint cannot be satisfied: fewer eligible domains than replicas,
+or a `minDomains` floor that is not met. Either add capacity in another
+domain, or relax the rule to `whenUnsatisfiable: ScheduleAnyway`.
+
+**Pods all land in one zone anyway.** Check the constraint's selector as
+above. Also confirm your nodes actually carry the topology label —
+`kubectl get nodes -L topology.kubernetes.io/zone`. A `topologyKey` no node
+has means one domain, and one domain is always balanced.
+
+**A `placement` change hasn't taken effect.** The `Bind9Instance` controller
+watches `Bind9Cluster` and `ClusterBind9Provider`, so cluster-level edits
+normally reach Deployments within seconds. If not, check the instance's
+conditions: an invalid block is rejected with `Ready=False` naming the
+offending field.
+
+**Note on `kubectl patch --type=merge`.** JSON merge patch does not delete
+keys you omit. To clear an entire placement block, send it explicitly as
+`null`:
+
+```bash
+kubectl patch bind9cluster my-dns --type=merge \
+  -p '{"spec":{"primary":{"placement":null}}}'
+```
+
+## Related
+
+- [ADR-0003](https://github.com/firestoned/bindy/blob/main/docs/adr/0003-pod-placement-and-zone-spreading.md) — the design and what was deliberately left out
+- [Multi-Region Setup](multi-region.md) — spanning regions, not just zones
+- [`examples/zone-spreading.yaml`](https://github.com/firestoned/bindy/blob/main/examples/zone-spreading.yaml)

--- a/docs/src/installation/crds.md
+++ b/docs/src/installation/crds.md
@@ -18,19 +18,14 @@ CRDs define the schema for custom resources in Kubernetes. Bindy uses CRDs to re
 Install all Bindy CRDs from the latest release:
 
 ```bash
-kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml
+kubectl apply --server-side -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml
 ```
 
 Or install a specific version:
 
 ```bash
-kubectl apply -f https://github.com/firestoned/bindy/releases/download/v0.5.0/crds.yaml
+kubectl apply --server-side -f https://github.com/firestoned/bindy/releases/download/v0.5.0/crds.yaml
 ```
-
-This is the **recommended method** as it:
-- Installs all CRDs in a single command
-- Uses stable, tagged releases
-- Avoids GitHub's annotation size limits for large CRDs
 
 ### Install from Source
 
@@ -38,20 +33,51 @@ Install from local files:
 
 ```bash
 cd bindy
-kubectl create -f deploy/crds/
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
-**Important**: Use `kubectl create` instead of `kubectl apply` to avoid the 256KB annotation size limit that can occur with large CRDs like `Bind9Instance`.
+### `--server-side` is required, not optional
+
+The `Bind9Cluster`, `ClusterBind9Provider`, and `Bind9Instance` CRDs are large
+— several hundred kilobytes each — because they embed full Kubernetes schemas
+for the passthrough fields they accept (`service.spec`, `volumes`,
+`volumeMounts`, and so on).
+
+Plain `kubectl apply` is a *client-side* apply: it stores a copy of the whole
+manifest in the `kubectl.kubernetes.io/last-applied-configuration` annotation,
+and annotations are capped at 256 KB. Applying these CRDs client-side fails
+outright:
+
+```text
+The CustomResourceDefinition "bind9clusters.bindy.firestoned.io" is invalid:
+metadata.annotations: Too long: may not be more than 262144 bytes
+```
+
+`--server-side` tracks ownership in `metadata.managedFields` instead of that
+annotation, so the limit does not apply. It also works for **upgrades**, which
+is why it is preferred over `kubectl create`: `create` succeeds on a fresh
+cluster but fails with `AlreadyExists` when the CRDs are already installed.
+
+If you have previously installed these CRDs client-side, the first server-side
+apply may report a conflict. Resolve it once with:
+
+```bash
+kubectl apply --server-side --force-conflicts -f deploy/operator/crds/
+```
 
 ### Updating Existing CRDs
 
-To update CRDs that are already installed:
+Server-side apply handles updates too — the same command used to install:
 
 ```bash
-kubectl replace --force -f deploy/crds/
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
-The `--force` flag deletes and recreates the CRDs, which is necessary to avoid annotation size limits.
+Do **not** use `kubectl replace --force` for this. It deletes and recreates
+each CRD, and deleting a CRD cascades to every custom resource defined by it —
+so it would take all your `Bind9Cluster`, `DNSZone`, and record objects with
+it. It was previously recommended here as a way around the annotation size
+limit; `--server-side` solves that without the data loss.
 
 ## Verify Installation
 

--- a/docs/src/operations/faq.md
+++ b/docs/src/operations/faq.md
@@ -139,7 +139,7 @@ kubectl delete arecords,aaaarecords,cnamerecords,mxrecords,txtrecords \
 
 ### How do I upgrade Bindy?
 
-1. Update CRDs: `kubectl apply -k deploy/crds/`
+1. Update CRDs: `kubectl apply --server-side -f deploy/operator/crds/`
 2. Update operator: `kubectl set image deployment/bindy bindy=new-image`
 3. Monitor rollout: `kubectl rollout status deployment/bindy -n bindy-system`
 

--- a/docs/src/operations/migration-guide.md
+++ b/docs/src/operations/migration-guide.md
@@ -239,7 +239,7 @@ kubectl apply -f https://github.com/firestoned/bindy/releases/download/v0.3.0/cr
 Or if installing from source:
 
 ```bash
-kubectl replace --force -f deploy/crds/
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
 **IMPORTANT:** Use `kubectl replace --force` instead of `kubectl apply` to avoid the 256KB annotation size limit.
@@ -460,7 +460,7 @@ kubectl get dnszone example-com -n bindy-system -o yaml | grep -A 5 recordsFrom
 **Symptom:** `kubectl apply` fails with "unknown field spec.zoneRef"
 
 **Solution:**
-- Update the CRDs to v0.3.0: `kubectl replace --force -f deploy/crds/`
+- Update the CRDs to v0.3.0: `kubectl apply --server-side -f deploy/operator/crds/`
 - Remove `spec.zoneRef` from your YAML files (field no longer exists)
 
 ## Rollback Procedure

--- a/docs/src/operations/rndc-key-rotation-migration.md
+++ b/docs/src/operations/rndc-key-rotation-migration.md
@@ -26,8 +26,8 @@ Before migrating, ensure:
 1. **Bindy operator updated** to version supporting RNDC rotation (v0.4.0+)
 2. **CRDs regenerated** with latest schema:
    ```bash
-   kubectl replace --force -f deploy/crds/bind9instances.crd.yaml
-   kubectl replace --force -f deploy/crds/bind9clusters.crd.yaml
+   kubectl apply --server-side -f deploy/operator/crds/bind9instances.crd.yaml
+   kubectl apply --server-side -f deploy/operator/crds/bind9clusters.crd.yaml
    ```
 3. **Backup existing Secrets**:
    ```bash
@@ -376,7 +376,7 @@ kubectl exec -n bindy-system deployment/dns-primary -- cat /etc/bind/rndc.key
 
 1. **CRD schema not updated**:
    ```bash
-   kubectl replace --force -f deploy/crds/bind9instances.crd.yaml
+   kubectl apply --server-side -f deploy/operator/crds/bind9instances.crd.yaml
    ```
 
 2. **Auto-rotation disabled**:

--- a/docs/src/reference/examples-simple.md
+++ b/docs/src/reference/examples-simple.md
@@ -202,7 +202,7 @@ kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/cr
 Or from local files:
 
 ```bash
-kubectl apply -k deploy/crds/
+kubectl apply --server-side -f deploy/operator/crds/
 ```
 
 ### 2. Install RBAC

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ This directory contains example YAML manifests for deploying and configuring Bin
 
 ## ⚠️ Important: Schema Validation
 
-All examples in this directory MUST be valid and match the CRD schemas in `/deploy/crds/`.
+All examples in this directory MUST be valid and match the CRD schemas in `/deploy/operator/crds/`.
 
 After any CRD changes, run:
 
@@ -174,6 +174,18 @@ metadata:
    - Bind9Cluster with persistent volumes
    - Instance-level storage overrides
 
+### High Availability / Scheduling
+
+8. **[zone-spreading.yaml](zone-spreading.yaml)** - Spreading DNS servers across failure domains
+   - The operator default (no configuration needed for a soft zone spread)
+   - Hard `DoNotSchedule` spreading with `minDomains` for known multi-zone clusters
+   - Custom failure domains (racks, regions) via any node label
+   - Standalone-instance spreading, and how to opt out with `spread: []`
+   - Note: `placement` covers topology spreading only — no `nodeSelector`,
+     `tolerations`, or `affinity`. See
+     [ADR-0003](../docs/adr/0003-pod-placement-and-zone-spreading.md)
+   - See the [Zone Spreading guide](https://firestoned.github.io/bindy/guide/zone-spreading/)
+
 ## Quick Start
 
 ### Prerequisites: Install Bindy
@@ -183,7 +195,7 @@ Before running the examples, install Bindy:
 ```bash
 # Install from latest release (recommended)
 kubectl create namespace bindy-system
-kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml
+kubectl apply --server-side -f https://github.com/firestoned/bindy/releases/latest/download/crds.yaml
 kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/rbac/serviceaccount.yaml
 kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/rbac/role.yaml
 kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/rbac/rolebinding.yaml
@@ -191,8 +203,8 @@ kubectl apply -f https://github.com/firestoned/bindy/releases/latest/download/op
 
 # Or install from local files (development)
 kubectl create namespace bindy-system
-kubectl apply -k ../deploy/crds/
-kubectl apply -f ../deploy/rbac/
+kubectl apply --server-side -f ../deploy/operator/crds/
+kubectl apply -f ../deploy/operator/rbac/
 kubectl apply -f ../deploy/operator/deployment.yaml
 ```
 
@@ -285,4 +297,4 @@ These examples use placeholder values. Customize them for your environment:
 
 - [Quickstart Guide](../docs/src/installation/quickstart.md)
 - [API Reference](../docs/src/reference/api.md)
-- [CRD Schemas](../deploy/crds/)
+- [CRD Schemas](../deploy/operator/crds/)

--- a/examples/zone-spreading.yaml
+++ b/examples/zone-spreading.yaml
@@ -1,0 +1,162 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# Spreading DNS servers across availability zones.
+#
+# Why this matters: a zone's NS records name the individual servers
+# authoritative for it, so Bindy gives each nameserver its own Bind9Instance,
+# Deployment, and Service. `primary.replicas: 3` therefore creates three
+# single-Pod Deployments — and without a topology spread constraint the
+# scheduler is free to put all three in one zone. A zone outage then takes out
+# every primary at once, defeating the point of running three.
+#
+# Apply with:
+#   kubectl apply -f examples/zone-spreading.yaml
+---
+# ---------------------------------------------------------------------------
+# 1. The default. No `placement` block at all.
+#
+# With two or more PRIMARIES the operator applies a soft zone spread on its
+# own: maxSkew 1 over topology.kubernetes.io/zone, scoped to the role, with
+# whenUnsatisfiable: ScheduleAnyway. Zones fill evenly when they can, and a
+# single-zone cluster still schedules rather than hanging in Pending.
+#
+# Secondaries get NO default — see example 2 for how they opt in. A primary is
+# authoritative and holds the writable copy of a zone; a secondary can be
+# rebuilt from a primary. Defaulting secondaries would also silently change
+# where already-running Pods schedule on an operator upgrade.
+#
+# This is the whole configuration most users need.
+# ---------------------------------------------------------------------------
+apiVersion: bindy.firestoned.io/v1beta1
+kind: Bind9Cluster
+metadata:
+  name: dns-defaults
+  namespace: bindy-system
+spec:
+  version: "9.18"
+  primary:
+    replicas: 3
+  secondary:
+    replicas: 3
+---
+# ---------------------------------------------------------------------------
+# 2. Hard spread, for a cluster you know has at least three zones.
+#
+# `DoNotSchedule` guarantees the spread instead of merely preferring it, and
+# `minDomains: 3` makes the constraint fail loudly if fewer than three zones
+# are available — better than silently running all three primaries in one zone
+# and finding out during the outage.
+#
+# Only do this when the cluster really has that many zones: a hard constraint
+# turns a shortfall into Pending DNS Pods.
+# ---------------------------------------------------------------------------
+apiVersion: bindy.firestoned.io/v1beta1
+kind: Bind9Cluster
+metadata:
+  name: dns-strict-zones
+  namespace: bindy-system
+spec:
+  version: "9.18"
+  primary:
+    replicas: 3
+    placement:
+      spread:
+        - topologyKey: topology.kubernetes.io/zone
+          maxSkew: 1
+          whenUnsatisfiable: DoNotSchedule
+          minDomains: 3
+  secondary:
+    replicas: 3
+    # Secondaries have no default, so this block is how they opt IN. Keep them
+    # soft: if a zone is down, a secondary stacking elsewhere is much better
+    # than no secondary at all.
+    placement:
+      spread:
+        - topologyKey: topology.kubernetes.io/zone
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+---
+# ---------------------------------------------------------------------------
+# 3. A custom failure domain.
+#
+# Not every cluster uses topology.kubernetes.io/zone. On-prem clusters often
+# label racks, power feeds, or cells instead — `topologyKey` takes any node
+# label, so spread across whatever your cluster actually has.
+#
+# Rules are applied in order and compose: spread across racks first, then
+# prefer separate hosts within a rack.
+#
+# Note there is no `nodeSelector` / `tolerations` / `affinity` here on purpose.
+# `placement` covers topology spreading only; see
+# docs/adr/0003-pod-placement-and-zone-spreading.md for why.
+# ---------------------------------------------------------------------------
+apiVersion: bindy.firestoned.io/v1beta1
+kind: Bind9Cluster
+metadata:
+  name: dns-onprem
+  namespace: bindy-system
+spec:
+  version: "9.18"
+  primary:
+    replicas: 3
+    placement:
+      spread:
+        # Rack first — the real failure domain in this cluster.
+        - topologyKey: failure-domain.acme.io/rack
+          maxSkew: 1
+          whenUnsatisfiable: DoNotSchedule
+        # Then prefer separate hosts within a rack.
+        - topologyKey: kubernetes.io/hostname
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+  secondary:
+    replicas: 3
+    placement:
+      spread:
+        - topologyKey: failure-domain.acme.io/rack
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+---
+# ---------------------------------------------------------------------------
+# 4. Standalone instance: spreading one server's own replicas.
+#
+# A standalone Bind9Instance with spec.replicas > 1 is one Deployment that
+# really does own every Pod in the set, so the default scope is `Instance`
+# rather than `Role`. No configuration needed — shown here explicitly.
+# ---------------------------------------------------------------------------
+apiVersion: bindy.firestoned.io/v1beta1
+kind: Bind9Instance
+metadata:
+  name: ns1
+  namespace: bindy-system
+spec:
+  clusterRef: ""
+  role: primary
+  replicas: 3
+  version: "9.18"
+  placement:
+    spread:
+      - topologyKey: topology.kubernetes.io/zone
+        maxSkew: 1
+        whenUnsatisfiable: ScheduleAnyway
+        scope: Instance
+---
+# ---------------------------------------------------------------------------
+# 5. Opting out.
+#
+# An empty list is the documented opt-out; omitting `spread` entirely gets you
+# the default instead. Useful on a single-zone cluster where the constraint is
+# pure scheduler overhead, or when an external scheduler owns placement.
+# ---------------------------------------------------------------------------
+apiVersion: bindy.firestoned.io/v1beta1
+kind: Bind9Cluster
+metadata:
+  name: dns-no-spread
+  namespace: bindy-system
+spec:
+  version: "9.18"
+  primary:
+    replicas: 3
+    placement:
+      spread: []

--- a/src/bin/crdgen.rs
+++ b/src/bin/crdgen.rs
@@ -54,7 +54,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("✓ Successfully generated CRD YAML files in deploy/operator/crds/");
     println!("\nNext steps:");
     println!("  1. Review the generated files");
-    println!("  2. Deploy with: kubectl apply -f deploy/operator/crds/");
+    println!("  2. Deploy with: kubectl apply --server-side -f deploy/operator/crds/");
+    println!();
+    println!("     --server-side is required: the Bind9Cluster / ClusterBind9Provider /");
+    println!("     Bind9Instance CRDs exceed the 256KB last-applied-configuration");
+    println!("     annotation limit, so a plain 'kubectl apply' is rejected.");
 
     Ok(())
 }

--- a/src/bind9_resources.rs
+++ b/src/bind9_resources.rs
@@ -440,6 +440,65 @@ pub fn build_labels_from_instance(
     labels
 }
 
+/// Builds the label set stamped onto the **Pods** of a `Bind9Instance`.
+///
+/// This is deliberately a superset of [`build_labels_from_instance`], which
+/// remains the Deployment's `spec.selector` and the Service's selector.
+///
+/// # Why the two are separate
+///
+/// `spec.selector` on a Deployment is **immutable** — Kubernetes rejects any
+/// change to it, because changing which Pods a Deployment claims would orphan
+/// the ones it used to own. When one label map fed both the selector and the
+/// Pod template (as it did before topology spreading landed), adding any new
+/// label to Pods would have changed the selector too, wedging the reconciler
+/// on every Deployment that already existed.
+///
+/// So: [`build_labels_from_instance`] is frozen and owns the selector, and
+/// everything added afterwards goes here. Kubernetes only requires that the
+/// selector *matches* the template labels, so the template may carry extras.
+/// Service selectors are subset matches and are unaffected.
+///
+/// # Extra labels
+///
+/// * `bindy.firestoned.io/cluster` — the owning cluster, taken from
+///   `spec.clusterRef`. Without it there is no label shared by the sibling
+///   single-Pod Deployments of a cluster, and so no way to write a topology
+///   spread selector that balances all primaries against each other.
+/// * `bindy.firestoned.io/role` — derived from `spec.role` rather than from
+///   the CR's metadata, so it is present even on a hand-written
+///   `Bind9Instance` that carries no role label. Only inserted when the
+///   selector does not already carry the key, so the Pod can never stop
+///   matching its own Deployment's selector.
+#[must_use]
+pub fn build_pod_labels_from_instance(
+    instance_name: &str,
+    instance: &Bind9Instance,
+) -> BTreeMap<String, String> {
+    use crate::labels::{BINDY_CLUSTER_LABEL, BINDY_ROLE_LABEL, ROLE_PRIMARY, ROLE_SECONDARY};
+
+    let mut labels = build_labels_from_instance(instance_name, instance);
+
+    if !instance.spec.cluster_ref.is_empty() {
+        labels.insert(
+            BINDY_CLUSTER_LABEL.to_string(),
+            instance.spec.cluster_ref.clone(),
+        );
+    }
+
+    labels
+        .entry(BINDY_ROLE_LABEL.to_string())
+        .or_insert_with(|| {
+            match instance.spec.role {
+                crate::crd::ServerRole::Primary => ROLE_PRIMARY,
+                crate::crd::ServerRole::Secondary => ROLE_SECONDARY,
+            }
+            .to_string()
+        });
+
+    labels
+}
+
 /// Builds owner references for a resource owned by a `Bind9Instance`
 ///
 /// Sets up cascade deletion so that when the `Bind9Instance` is deleted,
@@ -1247,6 +1306,48 @@ fn resolve_deployment_config<'a>(
     }
 }
 
+/// Counts how many instances of each role the owning cluster asks for.
+///
+/// Returns `(role_instance_count, cluster_instance_count)`, defaulting to
+/// `(1, 1)` for a standalone `Bind9Instance` that has no owning cluster.
+///
+/// These counts drive the *default* spread decision only. They matter because
+/// a cluster-managed instance always has `replicas: 1` — the cluster
+/// controller creates one single-Pod Deployment per nameserver — so replica
+/// count alone would never reach the "two or more Pods" threshold, and the
+/// default would never fire for exactly the topology it exists to protect.
+fn resolve_role_counts(
+    instance: &Bind9Instance,
+    cluster: Option<&Bind9Cluster>,
+    cluster_provider: Option<&crate::crd::ClusterBind9Provider>,
+) -> (i32, i32) {
+    let common = cluster
+        .map(|c| &c.spec.common)
+        .or_else(|| cluster_provider.map(|p| &p.spec.common));
+
+    let Some(common) = common else {
+        return (1, 1);
+    };
+
+    let primaries = common
+        .primary
+        .as_ref()
+        .and_then(|p| p.replicas)
+        .unwrap_or(0);
+    let secondaries = common
+        .secondary
+        .as_ref()
+        .and_then(|s| s.replicas)
+        .unwrap_or(0);
+
+    let role_count = match instance.spec.role {
+        crate::crd::ServerRole::Primary => primaries,
+        crate::crd::ServerRole::Secondary => secondaries,
+    };
+
+    (role_count.max(1), (primaries + secondaries).max(1))
+}
+
 pub fn build_deployment(
     name: &str,
     namespace: &str,
@@ -1263,10 +1364,30 @@ pub fn build_deployment(
         "Building Deployment for Bind9Instance"
     );
 
-    // Build labels, checking if instance is managed by a cluster
-    let labels = build_labels_from_instance(name, instance);
+    // Two label sets, deliberately. `selector_labels` is frozen and owns the
+    // Deployment's immutable `spec.selector`; `pod_labels` is a superset
+    // stamped on the Pod template. See `build_pod_labels_from_instance`.
+    let selector_labels = build_labels_from_instance(name, instance);
+    let pod_labels = build_pod_labels_from_instance(name, instance);
     let replicas = instance.spec.replicas.unwrap_or(1);
     debug!(replicas, "Deployment replica count");
+
+    // Resolve scheduling: instance -> role -> cluster, then turn the winning
+    // block (or the operator default) into concrete Pod spec fields.
+    let (role_instance_count, cluster_instance_count) =
+        resolve_role_counts(instance, cluster, cluster_provider);
+    let placement_config = crate::placement::resolve_placement(instance, cluster, cluster_provider);
+    let placement_ctx = crate::placement::PlacementContext {
+        instance_name: name,
+        cluster_name: (!instance.spec.cluster_ref.is_empty())
+            .then_some(instance.spec.cluster_ref.as_str()),
+        role: instance.spec.role,
+        instance_replicas: replicas,
+        role_instance_count,
+        cluster_instance_count,
+        instance_selector_labels: &selector_labels,
+    };
+    let placement = crate::placement::build_pod_placement(placement_config, &placement_ctx);
 
     let config = resolve_deployment_config(name, instance, cluster, cluster_provider);
 
@@ -1306,19 +1427,26 @@ pub fn build_deployment(
         metadata: ObjectMeta {
             name: Some(name.into()),
             namespace: Some(namespace.into()),
-            labels: Some(labels.clone()),
+            // Deployment metadata keeps the original (selector) label set:
+            // widening it is not needed for scheduling and would change a
+            // contract other tooling may select on. Only the Pod template
+            // gains the cluster label.
+            labels: Some(selector_labels.clone()),
             owner_references: Some(owner_refs),
             ..Default::default()
         },
         spec: Some(DeploymentSpec {
             replicas: Some(replicas),
+            // IMMUTABLE. Never widen this set — see
+            // `build_pod_labels_from_instance` for why new labels go on the
+            // Pod template instead.
             selector: LabelSelector {
-                match_labels: Some(labels.clone()),
+                match_labels: Some(selector_labels.clone()),
                 ..Default::default()
             },
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
-                    labels: Some(labels.clone()),
+                    labels: Some(pod_labels.clone()),
                     ..Default::default()
                 }),
                 spec: Some(build_pod_spec(
@@ -1330,6 +1458,7 @@ pub fn build_deployment(
                     all_volumes.as_ref(),
                     all_volume_mounts.as_ref(),
                     config.bindcar_config,
+                    &placement,
                 )),
             },
             ..Default::default()
@@ -1349,6 +1478,7 @@ pub fn build_deployment(
 /// * `custom_volumes` - Optional custom volumes to add
 /// * `custom_volume_mounts` - Optional custom volume mounts to add
 /// * `bindcar_config` - Optional API sidecar configuration
+/// * `placement` - Resolved topology spread constraints from `crate::placement`
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_lines)]
 fn build_pod_spec(
@@ -1360,6 +1490,7 @@ fn build_pod_spec(
     custom_volumes: Option<&Vec<Volume>>,
     custom_volume_mounts: Option<&Vec<VolumeMount>>,
     bindcar_config: Option<&crate::crd::BindcarConfig>,
+    placement: &crate::placement::ResolvedPlacement,
 ) -> PodSpec {
     // Determine image to use
     let image = if let Some(img_cfg) = image_config {
@@ -1494,6 +1625,9 @@ fn build_pod_spec(
         )),
         image_pull_secrets,
         service_account_name: Some(BIND9_SERVICE_ACCOUNT.into()),
+        // Scheduling. Topology spreading only — see `crate::placement` for why
+        // this is not a general pod-spec passthrough.
+        topology_spread_constraints: placement.topology_spread_constraints.clone(),
         security_context: Some(PodSecurityContext {
             run_as_user: Some(BIND9_NONROOT_UID),
             run_as_group: Some(BIND9_NONROOT_UID),

--- a/src/bind9_resources_tests.rs
+++ b/src/bind9_resources_tests.rs
@@ -26,6 +26,7 @@ mod tests {
                 ..Default::default()
             },
             spec: Bind9InstanceSpec {
+                placement: None,
                 cluster_ref: "test-cluster".to_string(),
                 role: crate::crd::ServerRole::Primary,
                 replicas: Some(2),
@@ -2729,5 +2730,320 @@ mod tests {
         );
         let secret = volume.secret.as_ref().unwrap();
         assert_eq!(secret.secret_name, Some("instance-keys".to_string()));
+    }
+
+    // ==================================================================
+    // Pod placement / topology spreading
+    // ==================================================================
+
+    fn cluster_with_primaries(primaries: i32) -> crate::crd::Bind9Cluster {
+        crate::crd::Bind9Cluster::new(
+            "my-dns",
+            crate::crd::Bind9ClusterSpec {
+                common: crate::crd::Bind9ClusterCommonSpec {
+                    version: Some("9.18".into()),
+                    primary: Some(crate::crd::PrimaryConfig {
+                        replicas: Some(primaries),
+                        ..Default::default()
+                    }),
+                    secondary: None,
+                    image: None,
+                    config_map_refs: None,
+                    global: None,
+                    rndc_secret_refs: None,
+                    acls: None,
+                    volumes: None,
+                    volume_mounts: None,
+                },
+            },
+        )
+    }
+
+    /// A cluster-managed instance: one replica, owned by `my-dns`.
+    fn managed_instance(name: &str) -> Bind9Instance {
+        let mut instance = create_test_instance(name);
+        instance.spec.cluster_ref = "my-dns".into();
+        instance.spec.replicas = Some(1);
+        instance
+    }
+
+    fn pod_spec_of(
+        deployment: &k8s_openapi::api::apps::v1::Deployment,
+    ) -> &k8s_openapi::api::core::v1::PodSpec {
+        deployment
+            .spec
+            .as_ref()
+            .unwrap()
+            .template
+            .spec
+            .as_ref()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_deployment_selector_excludes_the_cluster_label() {
+        // REGRESSION GUARD. `spec.selector` is immutable in Kubernetes: once a
+        // Deployment exists, any change is rejected with "field is immutable"
+        // and the operator wedges. The cluster label was added for topology
+        // spreading and must live on the Pod template ONLY.
+        let instance = managed_instance("my-dns-primary-0");
+        let deployment = build_deployment(
+            "my-dns-primary-0",
+            "dns",
+            &instance,
+            None,
+            None,
+            "test-rndc-key",
+        );
+
+        let selector = deployment
+            .spec
+            .as_ref()
+            .unwrap()
+            .selector
+            .match_labels
+            .as_ref()
+            .unwrap();
+        assert!(
+            !selector.contains_key("bindy.firestoned.io/cluster"),
+            "adding a label to spec.selector is a breaking change for every existing Deployment"
+        );
+
+        let pod_labels = deployment
+            .spec
+            .as_ref()
+            .unwrap()
+            .template
+            .metadata
+            .as_ref()
+            .unwrap()
+            .labels
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            pod_labels
+                .get("bindy.firestoned.io/cluster")
+                .map(String::as_str),
+            Some("my-dns")
+        );
+
+        // Kubernetes requires the selector to still match the template.
+        for (key, value) in selector {
+            assert_eq!(
+                pod_labels.get(key),
+                Some(value),
+                "selector key {key} must still match the Pod template"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pod_labels_carry_role_derived_from_spec() {
+        // Cluster-managed instances get the role label from their CR metadata,
+        // but a hand-written Bind9Instance may carry no labels at all. The Pod
+        // label is derived from spec.role so Role-scoped spreading works either
+        // way.
+        let instance = managed_instance("my-dns-primary-0");
+        assert!(instance.metadata.labels.is_none());
+
+        let labels =
+            crate::bind9_resources::build_pod_labels_from_instance("my-dns-primary-0", &instance);
+        assert_eq!(
+            labels.get("bindy.firestoned.io/role").map(String::as_str),
+            Some("primary")
+        );
+    }
+
+    #[test]
+    fn test_pod_labels_are_a_superset_of_selector_labels() {
+        // Two invariants depend on this:
+        //   1. Kubernetes requires spec.selector to match the Pod template, so
+        //      the template may add labels but never drop one.
+        //   2. The reconcile short-circuit in reconcilers/bind9instance/mod.rs
+        //      uses "Pod template is missing an operator-managed label" as its
+        //      upgrade signal, which only works if pod labels ⊇ selector labels.
+        for name in ["my-dns-primary-0", "solo"] {
+            let mut instance = create_test_instance(name);
+            if name == "solo" {
+                instance.spec.cluster_ref = String::new();
+            }
+            let selector = build_labels_from_instance(name, &instance);
+            let pod = crate::bind9_resources::build_pod_labels_from_instance(name, &instance);
+
+            for (key, value) in &selector {
+                assert_eq!(
+                    pod.get(key),
+                    Some(value),
+                    "pod labels dropped selector key {key} for {name}"
+                );
+            }
+            assert!(pod.len() >= selector.len());
+        }
+    }
+
+    #[test]
+    fn test_standalone_instance_pod_labels_have_no_cluster_label() {
+        let mut instance = create_test_instance("solo");
+        instance.spec.cluster_ref = String::new();
+        let labels = crate::bind9_resources::build_pod_labels_from_instance("solo", &instance);
+        assert!(!labels.contains_key("bindy.firestoned.io/cluster"));
+    }
+
+    #[test]
+    fn test_deployment_spreads_multi_primary_cluster_by_default() {
+        let instance = managed_instance("my-dns-primary-0");
+        let cluster = cluster_with_primaries(3);
+        let deployment = build_deployment(
+            "my-dns-primary-0",
+            "dns",
+            &instance,
+            Some(&cluster),
+            None,
+            "test-rndc-key",
+        );
+
+        let constraints = pod_spec_of(&deployment)
+            .topology_spread_constraints
+            .as_ref()
+            .expect("a 3-primary cluster gets a default zone spread");
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(constraints[0].topology_key, "topology.kubernetes.io/zone");
+        assert_eq!(constraints[0].when_unsatisfiable, "ScheduleAnyway");
+
+        let match_labels = constraints[0]
+            .label_selector
+            .as_ref()
+            .unwrap()
+            .match_labels
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            match_labels
+                .get("bindy.firestoned.io/cluster")
+                .map(String::as_str),
+            Some("my-dns")
+        );
+        assert_eq!(
+            match_labels
+                .get("bindy.firestoned.io/role")
+                .map(String::as_str),
+            Some("primary")
+        );
+    }
+
+    #[test]
+    fn test_deployment_has_no_spread_for_single_primary_cluster() {
+        let instance = managed_instance("my-dns-primary-0");
+        let cluster = cluster_with_primaries(1);
+        let deployment = build_deployment(
+            "my-dns-primary-0",
+            "dns",
+            &instance,
+            Some(&cluster),
+            None,
+            "test-rndc-key",
+        );
+        assert!(pod_spec_of(&deployment)
+            .topology_spread_constraints
+            .is_none());
+    }
+
+    #[test]
+    fn test_deployment_applies_role_level_placement() {
+        let instance = managed_instance("my-dns-primary-0");
+        let mut cluster = cluster_with_primaries(3);
+        cluster.spec.common.primary.as_mut().unwrap().placement =
+            Some(crate::crd::PlacementConfig {
+                spread: Some(vec![crate::crd::SpreadRule {
+                    topology_key: "failure-domain.acme.io/rack".into(),
+                    max_skew: Some(1),
+                    when_unsatisfiable: Some(crate::crd::WhenUnsatisfiable::DoNotSchedule),
+                    scope: None,
+                    min_domains: None,
+                    node_affinity_policy: None,
+                    node_taints_policy: None,
+                }]),
+            });
+
+        let deployment = build_deployment(
+            "my-dns-primary-0",
+            "dns",
+            &instance,
+            Some(&cluster),
+            None,
+            "test-rndc-key",
+        );
+        let pod = pod_spec_of(&deployment);
+
+        let constraints = pod.topology_spread_constraints.as_ref().unwrap();
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(constraints[0].topology_key, "failure-domain.acme.io/rack");
+        assert_eq!(constraints[0].when_unsatisfiable, "DoNotSchedule");
+    }
+
+    #[test]
+    fn test_instance_placement_overrides_role_placement() {
+        let mut instance = managed_instance("my-dns-primary-0");
+        instance.spec.placement = Some(crate::crd::PlacementConfig {
+            spread: Some(vec![]),
+        });
+
+        let mut cluster = cluster_with_primaries(3);
+        cluster.spec.common.primary.as_mut().unwrap().placement =
+            Some(crate::crd::PlacementConfig {
+                spread: Some(vec![crate::crd::SpreadRule {
+                    topology_key: "topology.kubernetes.io/zone".into(),
+                    max_skew: None,
+                    when_unsatisfiable: None,
+                    scope: None,
+                    min_domains: None,
+                    node_affinity_policy: None,
+                    node_taints_policy: None,
+                }]),
+            });
+
+        let deployment = build_deployment(
+            "my-dns-primary-0",
+            "dns",
+            &instance,
+            Some(&cluster),
+            None,
+            "test-rndc-key",
+        );
+        assert!(
+            pod_spec_of(&deployment)
+                .topology_spread_constraints
+                .is_none(),
+            "instance-level `spread: []` must win outright over the role block"
+        );
+    }
+
+    #[test]
+    fn test_standalone_multi_replica_instance_spreads_its_own_pods() {
+        let mut instance = create_test_instance("solo");
+        instance.spec.cluster_ref = String::new();
+        instance.spec.replicas = Some(3);
+
+        let deployment = build_deployment("solo", "dns", &instance, None, None, "test-rndc-key");
+        let constraints = pod_spec_of(&deployment)
+            .topology_spread_constraints
+            .as_ref()
+            .unwrap();
+
+        let match_labels = constraints[0]
+            .label_selector
+            .as_ref()
+            .unwrap()
+            .match_labels
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            match_labels
+                .get("app.kubernetes.io/instance")
+                .map(String::as_str),
+            Some("solo"),
+            "a standalone Deployment owns every Pod in its own set"
+        );
+        assert!(!match_labels.contains_key("bindy.firestoned.io/cluster"));
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -451,3 +451,36 @@ pub const ALLOWED_USER_PVC_PREFIX: &str = "bindy-";
 /// Required name prefix for any ConfigMap that the user references via a
 /// `configMap:` volume. Same rationale as [`ALLOWED_USER_SECRET_PREFIX`].
 pub const ALLOWED_USER_CONFIGMAP_PREFIX: &str = "bindy-";
+
+// ============================================================================
+// Pod Placement / Topology Spreading
+// ============================================================================
+//
+// Constants backing `spec.placement` (see `src/placement.rs`). The operator
+// spreads DNS pods across failure domains so a single zone outage cannot take
+// out every authoritative server at once.
+
+/// Well-known Kubernetes node label identifying the availability zone.
+///
+/// Used as the default `topologyKey` when the user does not configure
+/// `spec.placement.spread` explicitly. Clusters that label failure domains
+/// differently (racks, cells, custom regions) override this per spread rule.
+pub const TOPOLOGY_KEY_ZONE: &str = "topology.kubernetes.io/zone";
+
+/// Default `maxSkew` for generated topology spread constraints.
+///
+/// A skew of 1 is the tightest useful value: it forces the scheduler to fill
+/// every domain evenly before doubling up in any one of them.
+pub const DEFAULT_SPREAD_MAX_SKEW: i32 = 1;
+
+/// Maximum number of spread rules accepted on a single `placement.spread`.
+///
+/// Each rule becomes one `topologySpreadConstraint` on the Pod, and every
+/// constraint multiplies scheduler work per scheduling attempt. The cap keeps
+/// a malformed or hostile CR from degrading cluster-wide scheduling latency.
+///
+/// Kept in sync with the `maxItems` on `PlacementConfig::spread` in
+/// `src/crd.rs`, which is what actually enforces the limit at admission. This
+/// constant backs the reconcile-time backstop for clusters still running an
+/// older CRD revision.
+pub const MAX_SPREAD_RULES: usize = 8;

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -2808,6 +2808,266 @@ pub struct ServiceConfig {
     pub spec: Option<ServiceSpec>,
 }
 
+/// How the scheduler should react when a spread rule cannot be satisfied.
+///
+/// Mirrors Kubernetes `topologySpreadConstraints[].whenUnsatisfiable`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum WhenUnsatisfiable {
+    /// Refuse to schedule the Pod at all (hard constraint).
+    ///
+    /// Guarantees the spread, at the cost of leaving Pods `Pending` when there
+    /// are not enough distinct domains. Only safe when the cluster is known to
+    /// have at least as many domains as replicas.
+    DoNotSchedule,
+
+    /// Schedule anyway, preferring nodes that minimise skew (soft constraint).
+    ///
+    /// The scheduler still spreads whenever it can, but a single-zone cluster
+    /// (or a zone outage) degrades to stacking instead of an outage. This is
+    /// the operator default.
+    ScheduleAnyway,
+}
+
+/// Whether node affinity / taints are honoured when computing spread skew.
+///
+/// Mirrors Kubernetes `nodeAffinityPolicy` / `nodeTaintsPolicy`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum NodeInclusionPolicy {
+    /// Only nodes matching the Pod's node affinity / tolerations are counted.
+    Honor,
+    /// All nodes are counted, regardless of affinity / taints.
+    Ignore,
+}
+
+/// Which set of DNS Pods a spread rule balances across failure domains.
+///
+/// This is the field that makes zone spreading actually work in Bindy, and it
+/// exists because a DNS server is not an anonymous replica.
+///
+/// A `Bind9Cluster` with `primary.replicas: 3` does **not** create one
+/// three-Pod Deployment. Each primary is an individually addressable
+/// nameserver (its hostname ends up in an `NS` record), so the cluster
+/// controller creates three separate `Bind9Instance` resources, each backed by
+/// its own single-Pod Deployment. A spread constraint whose label selector
+/// matches only its own Deployment's Pods would therefore balance a set of
+/// size one — which is always trivially balanced, and spreads nothing.
+///
+/// `scope` selects the label selector the operator generates, and so decides
+/// which Pods the scheduler counts per domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum SpreadScope {
+    /// Balance only the Pods of this one `Bind9Instance`.
+    ///
+    /// Correct for a standalone `Bind9Instance` with `spec.replicas: 2` or
+    /// more, where one Deployment really does own every Pod in the set.
+    /// A no-op for cluster-managed instances, which have one Pod each.
+    Instance,
+
+    /// Balance every Pod of the same role across the whole cluster.
+    ///
+    /// Selects on `bindy.firestoned.io/cluster` + `bindy.firestoned.io/role`,
+    /// so all primaries of `my-dns` are balanced against each other (and all
+    /// secondaries separately against each other). This is the default for
+    /// cluster-managed instances and the setting that satisfies "spread
+    /// primaries across zones before stacking two in one zone".
+    Role,
+
+    /// Balance every Pod of the cluster, primaries and secondaries together.
+    ///
+    /// Selects on `bindy.firestoned.io/cluster` alone. Useful when total DNS
+    /// footprint per zone matters more than per-role balance — for example
+    /// when primaries and secondaries are sized alike and you simply want an
+    /// even spread of nameservers per zone. Set it on both `primary.placement`
+    /// and `secondary.placement` so every Pod carries the same constraint.
+    Cluster,
+}
+
+/// A single topology spread rule.
+///
+/// Each rule becomes exactly one entry in the Pod's
+/// `spec.topologySpreadConstraints`, with the `labelSelector` generated from
+/// [`SpreadScope`] rather than written by hand — users have no way to know the
+/// operator's internal Pod labels, and getting the selector wrong silently
+/// produces a constraint that does nothing.
+///
+/// # Example
+///
+/// ```yaml
+/// spread:
+///   # Spread primaries across zones first — hard requirement.
+///   - topologyKey: topology.kubernetes.io/zone
+///     maxSkew: 1
+///     whenUnsatisfiable: DoNotSchedule
+///     scope: Role
+///   # Then, within a zone, prefer separate nodes.
+///   - topologyKey: kubernetes.io/hostname
+///     maxSkew: 1
+///     whenUnsatisfiable: ScheduleAnyway
+///     scope: Role
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+// Cross-field rules the structural schema cannot express on its own. Enforcing
+// them here means the API server rejects a bad rule at admission, rather than
+// the user discovering it as a failed Deployment several reconciles later.
+#[schemars(extend("x-kubernetes-validations" = [
+    serde_json::json!({
+        "rule": "!has(self.minDomains) || (has(self.whenUnsatisfiable) && self.whenUnsatisfiable == 'DoNotSchedule')",
+        "message": "minDomains is only valid together with whenUnsatisfiable: DoNotSchedule"
+    }),
+    // The `topologyKey` pattern constrains the prefix charset but cannot bound
+    // its length: CRD patterns are RE2, which has no lookahead. `indexOf` is
+    // the prefix length when a '/' is present, and -1 when it is not.
+    serde_json::json!({
+        "rule": "self.topologyKey.indexOf('/') <= 253",
+        "message": "topologyKey prefix (the part before '/') must be at most 253 characters"
+    })
+]))]
+pub struct SpreadRule {
+    /// Node label key that defines the failure domain.
+    ///
+    /// Nodes sharing a value for this label are in the same domain. Any node
+    /// label works, which is the point: clusters that do not use the
+    /// well-known zone label can spread across whatever they do use.
+    ///
+    /// Examples:
+    /// - `topology.kubernetes.io/zone` - availability zone (the usual choice)
+    /// - `topology.kubernetes.io/region` - region, for multi-region clusters
+    /// - `kubernetes.io/hostname` - individual nodes
+    /// - `failure-domain.acme.io/rack` - a custom, on-prem failure domain
+    /// - `karpenter.sh/capacity-type` - spot vs. on-demand capacity
+    ///
+    /// Must be a valid Kubernetes qualified name, matching what the API server
+    /// accepts for a node label key: an optional lowercase RFC 1123 subdomain
+    /// prefix of at most 253 characters, a `/`, and a name segment of at most
+    /// 63 characters. The maximum overall length is therefore 317.
+    ///
+    /// The 253-character prefix cap is enforced by an
+    /// `x-kubernetes-validations` rule on the parent rule rather than by the
+    /// pattern below: CRD patterns are RE2, which has no lookahead, so a
+    /// length bound on a variable-length prefix cannot be expressed in the
+    /// regex itself.
+    #[schemars(length(min = 1, max = 317))]
+    #[schemars(regex(
+        pattern = r"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$"
+    ))]
+    pub topology_key: String,
+
+    /// Maximum permitted difference in Pod count between any two domains.
+    ///
+    /// Default: `1` (the tightest useful value — every domain is filled before
+    /// any domain doubles up).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 100))]
+    pub max_skew: Option<i32>,
+
+    /// What the scheduler does when the rule cannot be satisfied.
+    ///
+    /// Default: `ScheduleAnyway` (soft). The operator defaults to soft
+    /// deliberately: a hard constraint turns a single-zone cluster, or a zone
+    /// outage, into `Pending` DNS Pods — trading an availability problem for a
+    /// total outage. Set `DoNotSchedule` only when you know the cluster has at
+    /// least as many domains as you have replicas.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when_unsatisfiable: Option<WhenUnsatisfiable>,
+
+    /// Which Pods this rule balances. See [`SpreadScope`].
+    ///
+    /// Default: `Role` for a cluster-managed instance (spread all primaries of
+    /// the cluster across zones), `Instance` for a standalone `Bind9Instance`
+    /// (spread that instance's own replicas).
+    ///
+    /// The default is almost always what you want. Override it only when you
+    /// deliberately want primaries and secondaries balanced together
+    /// (`Cluster`), or want to opt a multi-replica standalone instance out of
+    /// cluster-wide balancing (`Instance`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<SpreadScope>,
+
+    /// Minimum number of domains that must be eligible.
+    ///
+    /// Only meaningful together with `whenUnsatisfiable: DoNotSchedule`. When
+    /// fewer than `minDomains` domains exist, the constraint is treated as
+    /// unsatisfiable. Use it to fail loudly rather than silently running all
+    /// your nameservers in one zone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 1000))]
+    pub min_domains: Option<i32>,
+
+    /// Whether the Pod's node affinity / node selector is honoured when
+    /// counting domains.
+    ///
+    /// Default: `Honor` (the Kubernetes default). `Ignore` counts every node,
+    /// including ones this Pod could never be scheduled onto.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_affinity_policy: Option<NodeInclusionPolicy>,
+
+    /// Whether node taints are honoured when counting domains.
+    ///
+    /// Default: `Ignore` (the Kubernetes default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_taints_policy: Option<NodeInclusionPolicy>,
+}
+
+/// Topology spreading for the Pods backing a DNS server.
+///
+/// Controls how nameservers are distributed across failure domains, so a zone
+/// (or rack, or whatever your cluster labels nodes with) going down cannot
+/// take out every authoritative server at once.
+///
+/// `placement` can be set at two levels, resolved highest-priority first:
+///
+/// 1. `Bind9Instance.spec.placement` — one specific DNS server
+/// 2. `spec.primary.placement` / `spec.secondary.placement` — one role, on the
+///    owning `Bind9Cluster` or `ClusterBind9Provider`
+///
+/// Resolution is whole-block: the more specific level wins outright rather
+/// than merging field-by-field, so what will be scheduled is answerable by
+/// reading one block.
+///
+/// # Scope
+///
+/// This type deliberately covers **only** topology spreading. It is not a
+/// general pod-spec passthrough: `nodeSelector`, `tolerations`, and `affinity`
+/// are not accepted here. Embedding the full Kubernetes `Affinity` and
+/// `Toleration` schemas inflated the generated CRDs by roughly 450KB and would
+/// have handed a namespace tenant the scheduling primitives needed to place an
+/// operator-credentialed Pod onto a control-plane node — a large validation and
+/// security surface for a feature whose job is zone spreading. See
+/// `docs/adr/0003-pod-placement-and-zone-spreading.md`.
+///
+/// # Example
+///
+/// ```yaml
+/// placement:
+///   spread:
+///     - topologyKey: failure-domain.acme.io/rack
+///       maxSkew: 1
+///       whenUnsatisfiable: DoNotSchedule
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PlacementConfig {
+    /// Topology spread rules applied to the Pods of this DNS server.
+    ///
+    /// Three distinct states:
+    ///
+    /// - **absent** — for a **primary** role with two or more servers, the
+    ///   operator applies its default: one soft (`ScheduleAnyway`) rule over
+    ///   `topology.kubernetes.io/zone` with `maxSkew: 1`. Secondaries and
+    ///   single-server roles get no constraint unless you ask for one.
+    /// - **empty list** (`spread: []`) — explicitly no spread constraints.
+    ///   Use this to opt a multi-primary cluster out of the default.
+    /// - **non-empty list** — exactly these rules, and no default. This is how
+    ///   secondaries opt *in*.
+    ///
+    /// At most 8 rules; each becomes one `topologySpreadConstraint`, and every
+    /// constraint is re-evaluated on each scheduling attempt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(max = 8))]
+    pub spread: Option<Vec<SpreadRule>>,
+}
+
 /// Primary instance configuration
 ///
 /// Groups all configuration specific to primary (authoritative) DNS instances.
@@ -2862,6 +3122,30 @@ pub struct PrimaryConfig {
     /// - Selector matching the instance labels (always set)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<ServiceConfig>,
+
+    /// Topology spreading for all primary instances in this cluster.
+    ///
+    /// This is the level most users want: it spreads every primary nameserver
+    /// of the cluster across failure domains, which is exactly what protects
+    /// against a zone outage taking out authoritative DNS.
+    ///
+    /// When unset, the operator applies a soft zone-spread default as soon as
+    /// `primary.replicas` is 2 or more. Overridden per-server by
+    /// `Bind9Instance.spec.placement`.
+    ///
+    /// # Example
+    ///
+    /// ```yaml
+    /// primary:
+    ///   replicas: 3
+    ///   placement:
+    ///     spread:
+    ///       - topologyKey: topology.kubernetes.io/zone
+    ///         maxSkew: 1
+    ///         whenUnsatisfiable: DoNotSchedule
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<PlacementConfig>,
 
     /// Allow-transfer ACL for primary instances
     ///
@@ -2979,6 +3263,31 @@ pub struct SecondaryConfig {
     /// See `PrimaryConfig.service` for detailed field documentation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service: Option<ServiceConfig>,
+
+    /// Topology spreading for all secondary instances in this cluster.
+    ///
+    /// **No default applies here.** The operator's automatic zone spread is
+    /// limited to primaries, which is what issue #467 asked for and what a
+    /// zone outage most threatens: primaries are authoritative and, unlike
+    /// secondaries, cannot be re-created from another server's data. Silently
+    /// changing where existing secondary workloads schedule would be an
+    /// unannounced policy change on a running cluster.
+    ///
+    /// Secondaries therefore opt in explicitly:
+    ///
+    /// ```yaml
+    /// secondary:
+    ///   replicas: 3
+    ///   placement:
+    ///     spread:
+    ///       - topologyKey: topology.kubernetes.io/zone
+    ///         maxSkew: 1
+    ///         whenUnsatisfiable: ScheduleAnyway
+    /// ```
+    ///
+    /// See `PrimaryConfig.placement` for field documentation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<PlacementConfig>,
 
     /// Allow-transfer ACL for secondary instances
     ///
@@ -3259,7 +3568,7 @@ pub struct Bind9ClusterStatus {
 /// Server role in the DNS cluster.
 ///
 /// Determines whether the instance is authoritative (primary) or replicates from primaries (secondary).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum ServerRole {
     /// Primary DNS server - authoritative source for zones.
@@ -3445,6 +3754,19 @@ pub struct Bind9InstanceSpec {
     /// ```
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rndc_key: Option<RndcKeyConfig>,
+
+    /// Topology spreading for this one DNS server's Pods.
+    ///
+    /// Highest-priority placement level: set here, it wins outright over the
+    /// role-level block rather than merging with it.
+    ///
+    /// For a standalone `Bind9Instance` with `spec.replicas` of 2 or more,
+    /// the default spread scope is `Instance` — the instance's own replicas
+    /// are balanced across zones. For a cluster-managed instance (one Pod
+    /// each) the default scope is `Role`, balancing this Pod against its
+    /// sibling instances of the same role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<PlacementConfig>,
 
     /// Storage configuration for zone files.
     ///

--- a/src/crd_tests.rs
+++ b/src/crd_tests.rs
@@ -347,6 +347,7 @@ mod tests {
     #[test]
     fn test_bind9instance_spec() {
         let spec = Bind9InstanceSpec {
+            placement: None,
             cluster_ref: "my-cluster".into(),
             role: ServerRole::Primary,
             replicas: Some(3),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod dns_errors;
 pub mod http_errors;
 pub mod labels;
 pub mod metrics;
+pub mod placement;
 pub mod record_impls;
 pub mod record_operator;
 pub mod safe_volume;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1464,6 +1464,16 @@ async fn run_bind9instance_operator(context: Arc<Context>) -> Result<()> {
     let client_for_watch = client.clone();
     let stores_for_watch = context.stores.clone();
 
+    // Cluster / provider watches: an instance inherits configuration that is
+    // resolved against the LIVE cluster object at reconcile time rather than
+    // copied into the instance spec (see `crate::placement::resolve_placement`).
+    // Without these watches such a change would only reach the Deployment on
+    // the next 5-minute requeue.
+    let cluster_api = Api::<Bind9Cluster>::all(client.clone());
+    let provider_api = Api::<ClusterBind9Provider>::all(client.clone());
+    let stores_for_cluster_watch = context.stores.clone();
+    let stores_for_provider_watch = context.stores.clone();
+
     // DNSZone API for status-only watcher
     let dnszone_api = Api::<DNSZone>::all(client.clone());
 
@@ -1533,6 +1543,38 @@ async fn run_bind9instance_operator(context: Arc<Context>) -> Result<()> {
 
             // Return empty vec to avoid triggering full reconciliation
             vec![]
+        })
+        .watches(cluster_api, default_watcher_config(), move |cluster| {
+            // A Bind9Cluster changed: reconcile every instance that references
+            // it, so inherited configuration (placement, image, version, ...)
+            // reaches the Deployments immediately instead of on the next
+            // requeue.
+            let cluster_name = cluster.name_any();
+            let Some(cluster_namespace) = cluster.namespace() else {
+                return vec![];
+            };
+            stores_for_cluster_watch
+                .bind9_instances
+                .state()
+                .iter()
+                .filter(|instance| {
+                    instance.spec.cluster_ref == cluster_name
+                        && instance.namespace().as_deref() == Some(cluster_namespace.as_str())
+                })
+                .map(|instance| kube::runtime::reflector::ObjectRef::from_obj(instance.as_ref()))
+                .collect::<Vec<_>>()
+        })
+        .watches(provider_api, default_watcher_config(), move |provider| {
+            // Same, for the cluster-scoped provider. A provider's instances can
+            // live in any namespace, so only the name is matched.
+            let provider_name = provider.name_any();
+            stores_for_provider_watch
+                .bind9_instances
+                .state()
+                .iter()
+                .filter(|instance| instance.spec.cluster_ref == provider_name)
+                .map(|instance| kube::runtime::reflector::ObjectRef::from_obj(instance.as_ref()))
+                .collect::<Vec<_>>()
         })
         .run(reconcile_bind9instance_wrapper, error_policy, context)
         .for_each(|_| futures::future::ready(()))

--- a/src/placement.rs
+++ b/src/placement.rs
@@ -1,0 +1,627 @@
+// Copyright (c) 2025 Erick Bourgeois, firestoned
+// SPDX-License-Identifier: MIT
+
+//! Pod placement: topology spreading, node selection, tolerations, affinity.
+//!
+//! # Why this module exists
+//!
+//! A DNS server is not an anonymous replica. A zone's `NS` records name the
+//! individual servers authoritative for it, so every primary needs a stable
+//! identity and its own address. Bindy models that by giving each nameserver
+//! its own `Bind9Instance`, its own Deployment, and its own Service — which
+//! means a `Bind9Cluster` with `primary.replicas: 3` produces **three
+//! single-Pod Deployments**, not one three-Pod Deployment.
+//!
+//! That shape breaks the obvious implementation of zone spreading. A
+//! `topologySpreadConstraint` balances the set of Pods matched by its
+//! `labelSelector`, counted per value of `topologyKey`. If the operator
+//! generated a selector matching a Deployment's own Pods, the set would have
+//! exactly one member — always trivially balanced, so the constraint would be
+//! satisfied by any placement and all three primaries could still land in one
+//! zone.
+//!
+//! The fix is [`SpreadScope`]: the selector is generated to match *sibling*
+//! instances via `bindy.firestoned.io/cluster` + `bindy.firestoned.io/role`,
+//! so the scheduler counts all primaries of a cluster as one set. Users never
+//! write that selector themselves — they cannot know the operator's internal
+//! Pod labels, and a wrong selector fails silently rather than loudly.
+//!
+//! # Defaults
+//!
+//! With no `placement` block anywhere, the operator emits a single **soft**
+//! (`ScheduleAnyway`) zone-spread constraint whenever the resolved Pod set has
+//! two or more members. Soft is deliberate: a hard constraint turns a
+//! single-zone cluster — or a zone outage, the very thing this feature guards
+//! against — into `Pending` DNS Pods, trading degraded availability for a
+//! total outage.
+//!
+//! # Scope
+//!
+//! This module handles topology spreading and nothing else. It deliberately
+//! does **not** accept `nodeSelector`, `tolerations`, or `affinity`: those are
+//! general pod-spec passthrough, they inflated the generated CRDs by ~450KB,
+//! and they are exactly the primitives a namespace tenant would need to place
+//! an operator-credentialed Pod onto a control-plane node. Keeping them out
+//! removes that threat model rather than mitigating it. See
+//! `docs/adr/0003-pod-placement-and-zone-spreading.md`.
+//!
+//! What remains to validate is correctness, not security: rules Kubernetes
+//! would reject, caught here so the user sees a clear condition on the CR they
+//! edited instead of an opaque Deployment failure. Structural limits that the
+//! CRD schema *can* express (rule count, label-key syntax, value ranges, and
+//! the `minDomains`/`DoNotSchedule` pairing) are enforced at admission by the
+//! generated schema; this module is the backstop.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::TopologySpreadConstraint;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+use crate::constants::{DEFAULT_SPREAD_MAX_SKEW, MAX_SPREAD_RULES, TOPOLOGY_KEY_ZONE};
+use crate::crd::{
+    Bind9Cluster, Bind9Instance, ClusterBind9Provider, NodeInclusionPolicy, PlacementConfig,
+    ServerRole, SpreadRule, SpreadScope, WhenUnsatisfiable,
+};
+use crate::labels::{BINDY_CLUSTER_LABEL, BINDY_ROLE_LABEL, ROLE_PRIMARY, ROLE_SECONDARY};
+
+// ============================================================================
+// Resolved output
+// ============================================================================
+
+/// The Pod-spec field this module produces.
+///
+/// Built by [`build_pod_placement`] and applied onto the Deployment's Pod
+/// template by `crate::bind9_resources::build_pod_spec`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ResolvedPlacement {
+    /// Generated from `placement.spread` (or the operator default).
+    pub topology_spread_constraints: Option<Vec<TopologySpreadConstraint>>,
+}
+
+impl ResolvedPlacement {
+    /// True when nothing would be applied to the Pod spec.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.topology_spread_constraints.is_none()
+    }
+}
+
+/// Everything [`build_pod_placement`] needs to know about the instance whose
+/// Pod spec is being built.
+#[derive(Clone, Debug)]
+pub struct PlacementContext<'a> {
+    /// Name of the `Bind9Instance` (also the Deployment name).
+    pub instance_name: &'a str,
+    /// Owning cluster / provider name, or `None` for a standalone instance.
+    ///
+    /// `Role` and `Cluster` spread scopes are only meaningful with a cluster:
+    /// they select on `bindy.firestoned.io/cluster`, which a standalone
+    /// instance's Pods do not carry.
+    pub cluster_name: Option<&'a str>,
+    /// Role of this instance.
+    pub role: ServerRole,
+    /// Pods in this instance's own Deployment (`spec.replicas`).
+    pub instance_replicas: i32,
+    /// How many instances of this role the owning cluster asks for.
+    ///
+    /// `1` for a standalone instance. This is what makes the default fire for
+    /// a cluster of three single-Pod primaries, where `instance_replicas` on
+    /// its own would always be 1 and never reach the threshold.
+    pub role_instance_count: i32,
+    /// Total instances the cluster asks for across both roles.
+    ///
+    /// Only used to decide whether a `Cluster`-scoped default is worth
+    /// emitting.
+    pub cluster_instance_count: i32,
+    /// This Deployment's own Pod selector labels, used for `Instance` scope.
+    pub instance_selector_labels: &'a BTreeMap<String, String>,
+}
+
+// ============================================================================
+// Resolution (precedence)
+// ============================================================================
+
+/// Resolves which `placement` block applies to an instance.
+///
+/// Precedence, highest first:
+///
+/// 1. `Bind9Instance.spec.placement`
+/// 2. `spec.primary.placement` / `spec.secondary.placement` on the owning
+///    `Bind9Cluster` or `ClusterBind9Provider`
+///
+/// Resolution is **whole-block**: the more specific level wins outright and
+/// the other is not merged into it. Merging would make "what will actually be
+/// scheduled" unanswerable without mentally combining two blocks, and a
+/// silently half-inherited scheduling rule is a bad failure mode — a Pod that
+/// lands somewhere unexpected is hard to notice until a zone goes down.
+#[must_use]
+pub fn resolve_placement<'a>(
+    instance: &'a Bind9Instance,
+    cluster: Option<&'a Bind9Cluster>,
+    cluster_provider: Option<&'a ClusterBind9Provider>,
+) -> Option<&'a PlacementConfig> {
+    // 1. Instance level.
+    if let Some(p) = instance.spec.placement.as_ref() {
+        debug!(instance = %instance.spec.cluster_ref, "Using instance-level placement");
+        return Some(p);
+    }
+
+    // 2. Role level, then 3. cluster level — checked against the namespace-
+    //    scoped cluster first, then the cluster-scoped provider. An instance
+    //    only ever belongs to one of the two, so at most one arm contributes.
+    let role_level = match instance.spec.role {
+        ServerRole::Primary => cluster
+            .and_then(|c| c.spec.common.primary.as_ref())
+            .and_then(|p| p.placement.as_ref())
+            .or_else(|| {
+                cluster_provider
+                    .and_then(|p| p.spec.common.primary.as_ref())
+                    .and_then(|p| p.placement.as_ref())
+            }),
+        ServerRole::Secondary => cluster
+            .and_then(|c| c.spec.common.secondary.as_ref())
+            .and_then(|s| s.placement.as_ref())
+            .or_else(|| {
+                cluster_provider
+                    .and_then(|p| p.spec.common.secondary.as_ref())
+                    .and_then(|s| s.placement.as_ref())
+            }),
+    };
+    role_level
+}
+
+// ============================================================================
+// Building
+// ============================================================================
+
+/// Builds the Pod-spec placement fields for an instance.
+///
+/// `config` is the block returned by [`resolve_placement`]; `None` means no
+/// user configuration at any level, in which case only the operator default
+/// spread applies.
+#[must_use]
+pub fn build_pod_placement(
+    config: Option<&PlacementConfig>,
+    ctx: &PlacementContext<'_>,
+) -> ResolvedPlacement {
+    let constraints = match config.and_then(|c| c.spread.as_ref()) {
+        // Explicit rules: exactly these, no default.
+        Some(rules) if !rules.is_empty() => rules
+            .iter()
+            .filter_map(|rule| build_constraint(rule, ctx))
+            .collect::<Vec<_>>(),
+        // Explicit empty list: the user opted out.
+        Some(_) => {
+            debug!(
+                instance = %ctx.instance_name,
+                "placement.spread is an empty list; emitting no topology spread constraints"
+            );
+            Vec::new()
+        }
+        // Absent: operator default.
+        None => default_constraints(ctx),
+    };
+
+    ResolvedPlacement {
+        topology_spread_constraints: (!constraints.is_empty()).then_some(constraints),
+    }
+}
+
+/// The operator's default spread: one soft zone rule for **primaries only**,
+/// when the Pod set is large enough for spreading to mean anything.
+///
+/// # Why primaries only
+///
+/// Issue #467 asked for primaries, and the asymmetry is real: a primary is
+/// authoritative and holds the writable copy of a zone, whereas a secondary
+/// can be re-created from a primary at any time. Losing every primary to one
+/// zone outage is the failure this feature exists to prevent.
+///
+/// The other half of the reasoning is about upgrades. Applying a default to
+/// secondaries would silently change where already-running secondary Pods are
+/// scheduled the moment an operator is upgraded — an unannounced scheduling
+/// policy change on a live cluster, which is not something an operator should
+/// do on a user's behalf. Secondaries opt in via `secondary.placement.spread`.
+fn default_constraints(ctx: &PlacementContext<'_>) -> Vec<TopologySpreadConstraint> {
+    if ctx.role != ServerRole::Primary {
+        debug!(
+            instance = %ctx.instance_name,
+            "Default zone spread applies to primaries only; set secondary.placement.spread to opt in"
+        );
+        return Vec::new();
+    }
+
+    let default_rule = SpreadRule {
+        topology_key: TOPOLOGY_KEY_ZONE.to_string(),
+        max_skew: None,
+        when_unsatisfiable: None,
+        scope: None,
+        min_domains: None,
+        node_affinity_policy: None,
+        node_taints_policy: None,
+    };
+
+    let scope = effective_scope(&default_rule, ctx);
+    let set_size = pod_set_size(scope, ctx);
+
+    if set_size < 2 {
+        debug!(
+            instance = %ctx.instance_name,
+            set_size,
+            "Resolved Pod set has fewer than 2 members; skipping default zone spread"
+        );
+        return Vec::new();
+    }
+
+    debug!(
+        instance = %ctx.instance_name,
+        set_size,
+        scope = ?scope,
+        "Applying default soft zone spread"
+    );
+    build_constraint(&default_rule, ctx).into_iter().collect()
+}
+
+/// Number of Pods the scheduler will count for a given scope.
+///
+/// Used only to decide whether the *default* is worth emitting. Explicit user
+/// rules are always honoured, however small the set — the user asked for them.
+fn pod_set_size(scope: SpreadScope, ctx: &PlacementContext<'_>) -> i32 {
+    let replicas = ctx.instance_replicas.max(0);
+    match scope {
+        SpreadScope::Instance => replicas,
+        SpreadScope::Role => ctx.role_instance_count.max(1).saturating_mul(replicas),
+        SpreadScope::Cluster => ctx.cluster_instance_count.max(1).saturating_mul(replicas),
+    }
+}
+
+/// Picks the scope for a rule: explicit if set, else `Role` for a
+/// cluster-managed instance and `Instance` for a standalone one.
+fn effective_scope(rule: &SpreadRule, ctx: &PlacementContext<'_>) -> SpreadScope {
+    match rule.scope {
+        Some(scope) => scope,
+        None => {
+            if ctx.cluster_name.is_some() {
+                SpreadScope::Role
+            } else {
+                SpreadScope::Instance
+            }
+        }
+    }
+}
+
+/// Turns one [`SpreadRule`] into a Kubernetes `TopologySpreadConstraint`.
+///
+/// Returns `None` when the rule cannot produce a meaningful constraint — a
+/// cluster-scoped rule on a standalone instance, for instance, whose Pods
+/// carry no cluster label to select on.
+fn build_constraint(
+    rule: &SpreadRule,
+    ctx: &PlacementContext<'_>,
+) -> Option<TopologySpreadConstraint> {
+    let requested = effective_scope(rule, ctx);
+    let scope = match (requested, ctx.cluster_name) {
+        // Role / Cluster scope needs the cluster label, which only exists on
+        // Pods belonging to a cluster. Fall back rather than emitting a
+        // constraint whose selector matches nothing.
+        (SpreadScope::Role | SpreadScope::Cluster, None) => {
+            warn!(
+                instance = %ctx.instance_name,
+                requested_scope = ?requested,
+                "Spread scope requires an owning Bind9Cluster; falling back to Instance scope"
+            );
+            SpreadScope::Instance
+        }
+        (scope, _) => scope,
+    };
+
+    let label_selector = build_selector(scope, ctx);
+
+    let when_unsatisfiable = rule
+        .when_unsatisfiable
+        .unwrap_or(WhenUnsatisfiable::ScheduleAnyway);
+
+    Some(TopologySpreadConstraint {
+        topology_key: rule.topology_key.clone(),
+        max_skew: rule.max_skew.unwrap_or(DEFAULT_SPREAD_MAX_SKEW),
+        when_unsatisfiable: when_unsatisfiable_str(when_unsatisfiable).to_string(),
+        label_selector: Some(label_selector),
+        // `minDomains` only has meaning for a hard constraint; the API server
+        // rejects it alongside ScheduleAnyway.
+        min_domains: match when_unsatisfiable {
+            WhenUnsatisfiable::DoNotSchedule => rule.min_domains,
+            WhenUnsatisfiable::ScheduleAnyway => None,
+        },
+        node_affinity_policy: rule.node_affinity_policy.map(node_policy_str_owned),
+        node_taints_policy: rule.node_taints_policy.map(node_policy_str_owned),
+        match_label_keys: None,
+    })
+}
+
+/// Generates the `labelSelector` that defines the balanced Pod set.
+///
+/// This is the crux of the whole feature: get the selector wrong and the
+/// constraint is silently satisfied by every placement.
+fn build_selector(scope: SpreadScope, ctx: &PlacementContext<'_>) -> LabelSelector {
+    let match_labels = match scope {
+        // This Deployment's own Pods.
+        SpreadScope::Instance => ctx.instance_selector_labels.clone(),
+        // Every Pod of this role across the cluster — i.e. all the sibling
+        // single-Pod Deployments the cluster controller created.
+        SpreadScope::Role => {
+            let mut m = BTreeMap::new();
+            if let Some(cluster) = ctx.cluster_name {
+                m.insert(BINDY_CLUSTER_LABEL.to_string(), cluster.to_string());
+            }
+            m.insert(BINDY_ROLE_LABEL.to_string(), role_str(ctx.role).to_string());
+            m
+        }
+        // Every DNS Pod of the cluster, both roles together.
+        SpreadScope::Cluster => {
+            let mut m = BTreeMap::new();
+            if let Some(cluster) = ctx.cluster_name {
+                m.insert(BINDY_CLUSTER_LABEL.to_string(), cluster.to_string());
+            }
+            m
+        }
+    };
+
+    LabelSelector {
+        match_labels: Some(match_labels),
+        ..Default::default()
+    }
+}
+
+fn role_str(role: ServerRole) -> &'static str {
+    match role {
+        ServerRole::Primary => ROLE_PRIMARY,
+        ServerRole::Secondary => ROLE_SECONDARY,
+    }
+}
+
+fn when_unsatisfiable_str(value: WhenUnsatisfiable) -> &'static str {
+    match value {
+        WhenUnsatisfiable::DoNotSchedule => "DoNotSchedule",
+        WhenUnsatisfiable::ScheduleAnyway => "ScheduleAnyway",
+    }
+}
+
+fn node_policy_str_owned(value: NodeInclusionPolicy) -> String {
+    match value {
+        NodeInclusionPolicy::Honor => "Honor".to_string(),
+        NodeInclusionPolicy::Ignore => "Ignore".to_string(),
+    }
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/// Rejection reasons returned by [`validate_placement`].
+///
+/// These are **correctness** checks, not security checks. Since `placement`
+/// accepts topology spreading only, there is no scheduling primitive here that
+/// could place a Pod somewhere it is not otherwise allowed — see the module
+/// docs. Each variant carries enough context for the reconciler to render an
+/// actionable `Ready=False` condition on the offending CR.
+///
+/// Most of these are also enforced structurally by the generated CRD schema
+/// (`maxItems`, the `topologyKey` pattern, value ranges, and an
+/// `x-kubernetes-validations` rule for the `minDomains` pairing), so they are
+/// normally rejected at admission. This validator remains the backstop for
+/// clusters running an older CRD revision, and covers the one rule a
+/// structural schema cannot express cheaply: uniqueness across rules.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PlacementRejection {
+    #[error(
+        "placement.spread has {count} rules, which exceeds the maximum of {MAX_SPREAD_RULES}; \
+         every rule is evaluated on each scheduling attempt"
+    )]
+    TooManySpreadRules { count: usize },
+
+    #[error(
+        "placement.spread[{index}].topologyKey {key:?} is not a valid Kubernetes label key: {reason}"
+    )]
+    InvalidTopologyKey {
+        index: usize,
+        key: String,
+        reason: &'static str,
+    },
+
+    #[error(
+        "placement.spread has two rules with the same topologyKey {key:?} and whenUnsatisfiable \
+         {when:?}; Kubernetes requires this pair to be unique across constraints"
+    )]
+    DuplicateSpreadRule { key: String, when: String },
+
+    #[error("placement.spread[{index}].maxSkew must be greater than 0, got {value}")]
+    InvalidMaxSkew { index: usize, value: i32 },
+
+    #[error("placement.spread[{index}].minDomains must be greater than 0, got {value}")]
+    InvalidMinDomains { index: usize, value: i32 },
+
+    #[error(
+        "placement.spread[{index}] sets minDomains, which Kubernetes only permits together with \
+         whenUnsatisfiable: DoNotSchedule"
+    )]
+    MinDomainsRequiresHardConstraint { index: usize },
+}
+
+/// Validates a user-supplied `placement` block.
+///
+/// Catches inputs Kubernetes itself would reject, so the user sees a clear
+/// condition on their CR instead of a Deployment that silently fails to apply.
+///
+/// # Errors
+///
+/// Returns the first [`PlacementRejection`] encountered.
+pub fn validate_placement(config: &PlacementConfig) -> Result<(), PlacementRejection> {
+    if let Some(rules) = config.spread.as_ref() {
+        validate_spread_rules(rules)?;
+    }
+    Ok(())
+}
+
+/// Convenience wrapper for the common `Option<&PlacementConfig>` shape.
+///
+/// # Errors
+///
+/// Returns the first [`PlacementRejection`] encountered, or `Ok(())` when the
+/// block is absent.
+pub fn validate_optional_placement(
+    config: Option<&PlacementConfig>,
+) -> Result<(), PlacementRejection> {
+    config.map_or(Ok(()), validate_placement)
+}
+
+fn validate_spread_rules(rules: &[SpreadRule]) -> Result<(), PlacementRejection> {
+    if rules.len() > MAX_SPREAD_RULES {
+        return Err(PlacementRejection::TooManySpreadRules { count: rules.len() });
+    }
+
+    let mut seen: Vec<(String, String)> = Vec::with_capacity(rules.len());
+
+    for (index, rule) in rules.iter().enumerate() {
+        if let Err(reason) = validate_label_key(&rule.topology_key) {
+            return Err(PlacementRejection::InvalidTopologyKey {
+                index,
+                key: rule.topology_key.clone(),
+                reason,
+            });
+        }
+
+        if let Some(skew) = rule.max_skew {
+            if skew <= 0 {
+                return Err(PlacementRejection::InvalidMaxSkew { index, value: skew });
+            }
+        }
+
+        let when = rule
+            .when_unsatisfiable
+            .unwrap_or(WhenUnsatisfiable::ScheduleAnyway);
+
+        if let Some(min_domains) = rule.min_domains {
+            if min_domains <= 0 {
+                return Err(PlacementRejection::InvalidMinDomains {
+                    index,
+                    value: min_domains,
+                });
+            }
+            if when != WhenUnsatisfiable::DoNotSchedule {
+                return Err(PlacementRejection::MinDomainsRequiresHardConstraint { index });
+            }
+        }
+
+        // Kubernetes requires (topologyKey, whenUnsatisfiable) to be unique
+        // across a Pod's constraints and rejects the Pod otherwise. Catching
+        // it here turns an opaque Deployment-level failure into a condition on
+        // the CR the user actually edited.
+        let key = (
+            rule.topology_key.clone(),
+            when_unsatisfiable_str(when).to_string(),
+        );
+        if seen.contains(&key) {
+            return Err(PlacementRejection::DuplicateSpreadRule {
+                key: key.0,
+                when: key.1,
+            });
+        }
+        seen.push(key);
+    }
+
+    Ok(())
+}
+
+/// Validates a Kubernetes label key, matching `IsQualifiedName` in
+/// `k8s.io/apimachinery/pkg/util/validation`.
+///
+/// An optional lowercase RFC 1123 subdomain prefix of at most 253 characters,
+/// a `/`, and a name segment of at most 63 characters — so 317 overall.
+///
+/// # Deliberately not enforced: a 63-character cap per DNS label
+///
+/// RFC 1123 caps a single DNS label at 63 octets, but Kubernetes'
+/// `IsDNS1123Subdomain` checks only the 253-character total and the subdomain
+/// charset — it does not bound individual labels. A key such as
+/// `<64 a's>/zone` is therefore accepted by the API server, both as a node
+/// label and as a `topologyKey` on a Pod (verified against a live cluster).
+/// Rejecting it here would make Bindy refuse input Kubernetes accepts, which
+/// is worse than mirroring the platform's own looseness.
+fn validate_label_key(key: &str) -> Result<(), &'static str> {
+    if key.is_empty() {
+        return Err("must not be empty");
+    }
+    // 253 (prefix) + 1 ('/') + 63 (name). An earlier revision used 316 here,
+    // which rejected a maximally-sized but perfectly valid key.
+    if key.len() > 317 {
+        return Err("must be at most 317 characters");
+    }
+
+    let name = match key.split_once('/') {
+        Some((prefix, name)) => {
+            if prefix.is_empty() {
+                return Err("prefix before '/' must not be empty");
+            }
+            if prefix.len() > 253 {
+                return Err("prefix before '/' must be at most 253 characters");
+            }
+            if !prefix.split('.').all(is_dns1123_label) {
+                return Err(
+                    "prefix before '/' must be a lowercase RFC 1123 subdomain: dot-separated \
+                     segments of alphanumerics and '-', each starting and ending with an \
+                     alphanumeric",
+                );
+            }
+            name
+        }
+        None => key,
+    };
+
+    if name.is_empty() {
+        return Err("name segment must not be empty");
+    }
+    if name.len() > 63 {
+        return Err("name segment must be at most 63 characters");
+    }
+    if !name.chars().all(is_label_name_char) {
+        return Err("name segment may contain only alphanumerics, '-', '_' and '.'");
+    }
+    if !starts_and_ends_alphanumeric(name) {
+        return Err("name segment must start and end with an alphanumeric character");
+    }
+
+    Ok(())
+}
+
+/// One dot-separated segment of an RFC 1123 subdomain, as Kubernetes validates
+/// it: non-empty, lowercase alphanumerics and `-`, starting and ending with an
+/// alphanumeric. Length is bounded by the caller's 253-character prefix cap;
+/// see `validate_label_key` for why there is no per-segment cap.
+fn is_dns1123_label(part: &str) -> bool {
+    !part.is_empty() && part.chars().all(is_dns_label_char) && starts_and_ends_alphanumeric(part)
+}
+
+fn starts_and_ends_alphanumeric(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && value
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+}
+
+fn is_dns_label_char(c: char) -> bool {
+    c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'
+}
+
+fn is_label_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'
+}
+
+#[cfg(test)]
+#[path = "placement_tests.rs"]
+mod placement_tests;

--- a/src/placement_tests.rs
+++ b/src/placement_tests.rs
@@ -1,0 +1,828 @@
+// Copyright (c) 2025 Erick Bourgeois, firestoned
+// SPDX-License-Identifier: MIT
+
+//! Unit tests for `placement`.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use kube::api::ObjectMeta;
+
+    use crate::crd::{
+        Bind9Cluster, Bind9ClusterCommonSpec, Bind9ClusterSpec, Bind9Instance, Bind9InstanceSpec,
+        ClusterBind9Provider, ClusterBind9ProviderSpec, NodeInclusionPolicy, PlacementConfig,
+        PrimaryConfig, SecondaryConfig, ServerRole, SpreadRule, SpreadScope, WhenUnsatisfiable,
+    };
+    use crate::placement::{
+        build_pod_placement, resolve_placement, validate_placement, PlacementContext,
+        PlacementRejection,
+    };
+
+    // ------------------------------------------------------------------
+    // Fixtures
+    // ------------------------------------------------------------------
+
+    fn instance(name: &str, role: ServerRole, cluster_ref: &str, replicas: i32) -> Bind9Instance {
+        #[allow(deprecated)]
+        Bind9Instance {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                namespace: Some("dns".into()),
+                ..Default::default()
+            },
+            spec: Bind9InstanceSpec {
+                cluster_ref: cluster_ref.to_string(),
+                role,
+                replicas: Some(replicas),
+                version: None,
+                image: None,
+                config_map_refs: None,
+                config: None,
+                primary_servers: None,
+                volumes: None,
+                volume_mounts: None,
+                rndc_secret_ref: None,
+                rndc_key: None,
+                storage: None,
+                placement: None,
+                bindcar_config: None,
+            },
+            status: None,
+        }
+    }
+
+    fn common_spec() -> Bind9ClusterCommonSpec {
+        Bind9ClusterCommonSpec {
+            version: Some("9.18".into()),
+            primary: None,
+            secondary: None,
+            image: None,
+            config_map_refs: None,
+            global: None,
+            rndc_secret_refs: None,
+            acls: None,
+            volumes: None,
+            volume_mounts: None,
+        }
+    }
+
+    fn cluster(common: Bind9ClusterCommonSpec) -> Bind9Cluster {
+        Bind9Cluster::new("my-dns", Bind9ClusterSpec { common })
+    }
+
+    fn provider(common: Bind9ClusterCommonSpec) -> ClusterBind9Provider {
+        ClusterBind9Provider::new(
+            "shared-dns",
+            ClusterBind9ProviderSpec {
+                namespace: Some("bindy-system".into()),
+                common,
+            },
+        )
+    }
+
+    fn selector_labels() -> BTreeMap<String, String> {
+        let mut m = BTreeMap::new();
+        m.insert("app".into(), "bind9".into());
+        m.insert(
+            "app.kubernetes.io/instance".into(),
+            "my-dns-primary-0".into(),
+        );
+        m
+    }
+
+    /// A cluster-managed primary: one Pod, three sibling instances.
+    fn managed_ctx<'a>(labels: &'a BTreeMap<String, String>) -> PlacementContext<'a> {
+        PlacementContext {
+            instance_name: "my-dns-primary-0",
+            cluster_name: Some("my-dns"),
+            role: ServerRole::Primary,
+            instance_replicas: 1,
+            role_instance_count: 3,
+            cluster_instance_count: 5,
+            instance_selector_labels: labels,
+        }
+    }
+
+    /// A standalone instance with its own replicas and no owning cluster.
+    fn standalone_ctx<'a>(
+        labels: &'a BTreeMap<String, String>,
+        replicas: i32,
+    ) -> PlacementContext<'a> {
+        PlacementContext {
+            instance_name: "solo",
+            cluster_name: None,
+            role: ServerRole::Primary,
+            instance_replicas: replicas,
+            role_instance_count: 1,
+            cluster_instance_count: 1,
+            instance_selector_labels: labels,
+        }
+    }
+
+    fn rule(topology_key: &str) -> SpreadRule {
+        SpreadRule {
+            topology_key: topology_key.into(),
+            max_skew: None,
+            when_unsatisfiable: None,
+            scope: None,
+            min_domains: None,
+            node_affinity_policy: None,
+            node_taints_policy: None,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Resolution precedence
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resolve_returns_none_when_nothing_is_configured() {
+        let inst = instance("my-dns-primary-0", ServerRole::Primary, "my-dns", 1);
+        let c = cluster(common_spec());
+        assert!(resolve_placement(&inst, Some(&c), None).is_none());
+    }
+
+    #[test]
+    fn resolve_prefers_instance_over_role() {
+        let mut inst = instance("my-dns-primary-0", ServerRole::Primary, "my-dns", 1);
+        inst.spec.placement = Some(PlacementConfig {
+            spread: Some(vec![rule("instance-level")]),
+        });
+
+        let mut common = common_spec();
+        common.primary = Some(PrimaryConfig {
+            placement: Some(PlacementConfig {
+                spread: Some(vec![rule("role-level")]),
+            }),
+            ..Default::default()
+        });
+        let c = cluster(common);
+
+        let resolved = resolve_placement(&inst, Some(&c), None).expect("placement resolves");
+        assert_eq!(
+            resolved.spread.as_ref().unwrap()[0].topology_key,
+            "instance-level"
+        );
+    }
+
+    #[test]
+    fn resolve_returns_none_when_the_role_block_sets_no_placement() {
+        // A primary block that exists but does not set `placement` must not be
+        // mistaken for a configured empty block — the caller needs `None` here
+        // so the operator default can apply.
+        let inst = instance("my-dns-primary-0", ServerRole::Primary, "my-dns", 1);
+        let mut common = common_spec();
+        common.primary = Some(PrimaryConfig {
+            replicas: Some(3),
+            ..Default::default()
+        });
+        let c = cluster(common);
+
+        assert!(resolve_placement(&inst, Some(&c), None).is_none());
+    }
+
+    #[test]
+    fn resolve_uses_the_role_block_matching_the_instance_role() {
+        let secondary = instance("my-dns-secondary-0", ServerRole::Secondary, "my-dns", 1);
+
+        let mut common = common_spec();
+        common.primary = Some(PrimaryConfig {
+            placement: Some(PlacementConfig {
+                spread: Some(vec![rule("primary-only")]),
+            }),
+            ..Default::default()
+        });
+        common.secondary = Some(SecondaryConfig {
+            placement: Some(PlacementConfig {
+                spread: Some(vec![rule("secondary-only")]),
+            }),
+            ..Default::default()
+        });
+        let c = cluster(common);
+
+        let resolved = resolve_placement(&secondary, Some(&c), None).unwrap();
+        assert_eq!(
+            resolved.spread.as_ref().unwrap()[0].topology_key,
+            "secondary-only"
+        );
+    }
+
+    #[test]
+    fn resolve_reads_from_a_cluster_scoped_provider() {
+        let inst = instance("shared-dns-primary-0", ServerRole::Primary, "shared-dns", 1);
+        let mut common = common_spec();
+        common.primary = Some(PrimaryConfig {
+            placement: Some(PlacementConfig {
+                spread: Some(vec![rule("provider-role-level")]),
+            }),
+            ..Default::default()
+        });
+        let p = provider(common);
+
+        let resolved = resolve_placement(&inst, None, Some(&p)).unwrap();
+        assert_eq!(
+            resolved.spread.as_ref().unwrap()[0].topology_key,
+            "provider-role-level"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Defaults
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn default_spreads_cluster_managed_primaries_across_zones() {
+        // The regression this whole feature exists to prevent: three primaries,
+        // one Pod each, all free to land in the same zone.
+        let labels = selector_labels();
+        let resolved = build_pod_placement(None, &managed_ctx(&labels));
+
+        let constraints = resolved
+            .topology_spread_constraints
+            .expect("default spread applies to a 3-primary cluster");
+        assert_eq!(constraints.len(), 1);
+
+        let c = &constraints[0];
+        assert_eq!(c.topology_key, "topology.kubernetes.io/zone");
+        assert_eq!(c.max_skew, 1);
+        assert_eq!(c.when_unsatisfiable, "ScheduleAnyway");
+
+        // The selector must match SIBLING Deployments, not just this one.
+        let match_labels = c
+            .label_selector
+            .as_ref()
+            .unwrap()
+            .match_labels
+            .clone()
+            .unwrap();
+        assert_eq!(
+            match_labels
+                .get("bindy.firestoned.io/cluster")
+                .map(String::as_str),
+            Some("my-dns")
+        );
+        assert_eq!(
+            match_labels
+                .get("bindy.firestoned.io/role")
+                .map(String::as_str),
+            Some("primary")
+        );
+        assert!(
+            !match_labels.contains_key("app.kubernetes.io/instance"),
+            "a per-instance selector would balance a set of one and spread nothing"
+        );
+    }
+
+    #[test]
+    fn default_is_soft_so_a_single_zone_cluster_still_schedules() {
+        let labels = selector_labels();
+        let resolved = build_pod_placement(None, &managed_ctx(&labels));
+        assert_eq!(
+            resolved.topology_spread_constraints.unwrap()[0].when_unsatisfiable,
+            "ScheduleAnyway"
+        );
+    }
+
+    #[test]
+    fn default_skipped_for_a_single_primary() {
+        let labels = selector_labels();
+        let mut ctx = managed_ctx(&labels);
+        ctx.role_instance_count = 1;
+        assert!(build_pod_placement(None, &ctx)
+            .topology_spread_constraints
+            .is_none());
+    }
+
+    #[test]
+    fn default_uses_instance_scope_for_a_standalone_multi_replica_instance() {
+        let labels = selector_labels();
+        let resolved = build_pod_placement(None, &standalone_ctx(&labels, 3));
+
+        let constraints = resolved.topology_spread_constraints.unwrap();
+        assert_eq!(constraints.len(), 1);
+        assert_eq!(
+            constraints[0].label_selector.as_ref().unwrap().match_labels,
+            Some(labels),
+            "a standalone Deployment really does own every Pod in the set"
+        );
+    }
+
+    #[test]
+    fn default_skipped_for_a_standalone_single_replica_instance() {
+        let labels = selector_labels();
+        let resolved = build_pod_placement(None, &standalone_ctx(&labels, 1));
+        assert!(resolved.topology_spread_constraints.is_none());
+    }
+
+    #[test]
+    fn default_does_not_apply_to_secondaries() {
+        // Issue #467 asked for primaries, and applying a default to secondaries
+        // would silently change where already-running secondary Pods schedule
+        // the moment the operator is upgraded.
+        let labels = selector_labels();
+        let mut ctx = managed_ctx(&labels);
+        ctx.role = ServerRole::Secondary;
+        ctx.instance_name = "my-dns-secondary-0";
+
+        assert!(
+            build_pod_placement(None, &ctx)
+                .topology_spread_constraints
+                .is_none(),
+            "secondaries must opt in via secondary.placement.spread"
+        );
+    }
+
+    #[test]
+    fn secondaries_can_opt_in_explicitly() {
+        let labels = selector_labels();
+        let mut ctx = managed_ctx(&labels);
+        ctx.role = ServerRole::Secondary;
+
+        let config = PlacementConfig {
+            spread: Some(vec![rule("topology.kubernetes.io/zone")]),
+        };
+        let constraints = build_pod_placement(Some(&config), &ctx)
+            .topology_spread_constraints
+            .expect("an explicit rule is honoured for secondaries");
+        assert_eq!(constraints.len(), 1);
+
+        // ...and the generated selector targets sibling SECONDARIES, not primaries.
+        let match_labels = constraints[0]
+            .label_selector
+            .as_ref()
+            .unwrap()
+            .match_labels
+            .clone()
+            .unwrap();
+        assert_eq!(
+            match_labels
+                .get("bindy.firestoned.io/role")
+                .map(String::as_str),
+            Some("secondary")
+        );
+    }
+
+    #[test]
+    fn default_does_not_apply_to_a_standalone_secondary() {
+        let labels = selector_labels();
+        let mut ctx = standalone_ctx(&labels, 3);
+        ctx.role = ServerRole::Secondary;
+        assert!(build_pod_placement(None, &ctx)
+            .topology_spread_constraints
+            .is_none());
+    }
+
+    #[test]
+    fn empty_spread_list_opts_out_of_the_default() {
+        let labels = selector_labels();
+        let config = PlacementConfig {
+            spread: Some(vec![]),
+        };
+        let resolved = build_pod_placement(Some(&config), &managed_ctx(&labels));
+        assert!(
+            resolved.topology_spread_constraints.is_none(),
+            "`spread: []` is the documented opt-out and must beat the default"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Explicit rules
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn explicit_rules_replace_the_default_entirely() {
+        let labels = selector_labels();
+        let config = PlacementConfig {
+            spread: Some(vec![
+                SpreadRule {
+                    topology_key: "failure-domain.acme.io/rack".into(),
+                    max_skew: Some(2),
+                    when_unsatisfiable: Some(WhenUnsatisfiable::DoNotSchedule),
+                    scope: Some(SpreadScope::Role),
+                    min_domains: Some(3),
+                    node_affinity_policy: Some(NodeInclusionPolicy::Honor),
+                    node_taints_policy: Some(NodeInclusionPolicy::Ignore),
+                },
+                rule("kubernetes.io/hostname"),
+            ]),
+        };
+
+        let constraints = build_pod_placement(Some(&config), &managed_ctx(&labels))
+            .topology_spread_constraints
+            .unwrap();
+        assert_eq!(constraints.len(), 2);
+
+        let rack = &constraints[0];
+        assert_eq!(rack.topology_key, "failure-domain.acme.io/rack");
+        assert_eq!(rack.max_skew, 2);
+        assert_eq!(rack.when_unsatisfiable, "DoNotSchedule");
+        assert_eq!(rack.min_domains, Some(3));
+        assert_eq!(rack.node_affinity_policy.as_deref(), Some("Honor"));
+        assert_eq!(rack.node_taints_policy.as_deref(), Some("Ignore"));
+
+        // No zone rule was requested, so none is emitted.
+        assert!(constraints
+            .iter()
+            .all(|c| c.topology_key != "topology.kubernetes.io/zone"));
+    }
+
+    #[test]
+    fn min_domains_dropped_for_a_soft_constraint() {
+        // Kubernetes rejects minDomains alongside ScheduleAnyway. Dropping it
+        // is friendlier than emitting a Pod spec the API server will refuse.
+        let labels = selector_labels();
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                min_domains: Some(3),
+                when_unsatisfiable: Some(WhenUnsatisfiable::ScheduleAnyway),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        let constraints = build_pod_placement(Some(&config), &managed_ctx(&labels))
+            .topology_spread_constraints
+            .unwrap();
+        assert_eq!(constraints[0].min_domains, None);
+    }
+
+    #[test]
+    fn cluster_scope_selects_on_the_cluster_label_alone() {
+        let labels = selector_labels();
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                scope: Some(SpreadScope::Cluster),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        let constraints = build_pod_placement(Some(&config), &managed_ctx(&labels))
+            .topology_spread_constraints
+            .unwrap();
+        let match_labels = constraints[0]
+            .label_selector
+            .as_ref()
+            .unwrap()
+            .match_labels
+            .clone()
+            .unwrap();
+        assert_eq!(match_labels.len(), 1);
+        assert_eq!(
+            match_labels
+                .get("bindy.firestoned.io/cluster")
+                .map(String::as_str),
+            Some("my-dns")
+        );
+    }
+
+    #[test]
+    fn role_scope_falls_back_to_instance_scope_without_a_cluster() {
+        // A standalone instance's Pods carry no cluster label, so a Role-scoped
+        // selector would match nothing and silently spread nothing.
+        let labels = selector_labels();
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                scope: Some(SpreadScope::Role),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        let constraints = build_pod_placement(Some(&config), &standalone_ctx(&labels, 2))
+            .topology_spread_constraints
+            .unwrap();
+        assert_eq!(
+            constraints[0].label_selector.as_ref().unwrap().match_labels,
+            Some(labels)
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Validation — correctness
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn valid_config_passes() {
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                max_skew: Some(1),
+                when_unsatisfiable: Some(WhenUnsatisfiable::DoNotSchedule),
+                min_domains: Some(3),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        assert!(validate_placement(&config).is_ok());
+    }
+
+    #[test]
+    fn rejects_too_many_spread_rules() {
+        let config = PlacementConfig {
+            spread: Some((0..9).map(|i| rule(&format!("key{i}"))).collect()),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::TooManySpreadRules { count: 9 })
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_topology_keys() {
+        for bad in ["", "bad key", "/name", "prefix/", &"x".repeat(64)] {
+            let config = PlacementConfig {
+                spread: Some(vec![rule(bad)]),
+            };
+            assert!(
+                matches!(
+                    validate_placement(&config),
+                    Err(PlacementRejection::InvalidTopologyKey { .. })
+                ),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_well_formed_topology_keys() {
+        for good in [
+            "topology.kubernetes.io/zone",
+            "kubernetes.io/hostname",
+            "failure-domain.acme.io/rack",
+            "karpenter.sh/capacity-type",
+            "zone",
+        ] {
+            let config = PlacementConfig {
+                spread: Some(vec![rule(good)]),
+            };
+            assert!(
+                validate_placement(&config).is_ok(),
+                "expected {good:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn topology_key_length_boundaries_match_kubernetes() {
+        // 253 (prefix) + '/' + 63 (name) = 317 is the largest key the API
+        // server accepts. An earlier revision capped at 316 and rejected it.
+        let prefix_253 = format!(
+            "{}.{}.{}.{}",
+            "a".repeat(63),
+            "a".repeat(63),
+            "a".repeat(63),
+            "a".repeat(61)
+        );
+        assert_eq!(prefix_253.len(), 253);
+        let name_63 = "b".repeat(63);
+        let max_key = format!("{prefix_253}/{name_63}");
+        assert_eq!(max_key.len(), 317);
+
+        let config = PlacementConfig {
+            spread: Some(vec![rule(&max_key)]),
+        };
+        assert!(
+            validate_placement(&config).is_ok(),
+            "a maximally-sized but valid qualified name must be accepted"
+        );
+
+        // 254-character prefix is over the DNS subdomain cap.
+        let prefix_254 = format!(
+            "{}.{}.{}.{}",
+            "a".repeat(63),
+            "a".repeat(63),
+            "a".repeat(63),
+            "a".repeat(62)
+        );
+        assert_eq!(prefix_254.len(), 254);
+        let config = PlacementConfig {
+            spread: Some(vec![rule(&format!("{prefix_254}/zone"))]),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::InvalidTopologyKey { .. })
+        ));
+
+        // 64-character name segment is over the qualified-name cap.
+        let config = PlacementConfig {
+            spread: Some(vec![rule(&format!("example.com/{}", "b".repeat(64)))]),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::InvalidTopologyKey { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_a_dns_label_longer_than_63_chars() {
+        // Kubernetes' IsDNS1123Subdomain bounds only the 253-character TOTAL,
+        // not individual labels, so `<64 a's>/zone` is accepted by the API
+        // server both as a node label and as a topologyKey. Rejecting it here
+        // would refuse input the platform accepts.
+        let config = PlacementConfig {
+            spread: Some(vec![rule(&format!("{}/zone", "a".repeat(64)))]),
+        };
+        assert!(validate_placement(&config).is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_dns_prefix_segments() {
+        // Each segment must start and end with an alphanumeric, be lowercase,
+        // and be non-empty — mirroring what the API server enforces.
+        for bad in [
+            "abc-/zone", // trailing hyphen
+            "-abc/zone", // leading hyphen
+            "Abc/zone",  // uppercase
+            "a..b/zone", // empty segment
+            "abc./zone", // trailing dot leaves an empty segment
+            "abc/-zone", // name segment starts with a hyphen
+            "abc/zone-", // name segment ends with a hyphen
+        ] {
+            let config = PlacementConfig {
+                spread: Some(vec![rule(bad)]),
+            };
+            assert!(
+                matches!(
+                    validate_placement(&config),
+                    Err(PlacementRejection::InvalidTopologyKey { .. })
+                ),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_topology_key_and_when_unsatisfiable_pairs() {
+        // Kubernetes rejects the Pod outright; catching it here surfaces a
+        // condition on the CR the user actually edited.
+        let config = PlacementConfig {
+            spread: Some(vec![
+                rule("topology.kubernetes.io/zone"),
+                rule("topology.kubernetes.io/zone"),
+            ]),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::DuplicateSpreadRule { .. })
+        ));
+    }
+
+    #[test]
+    fn allows_same_topology_key_with_different_when_unsatisfiable() {
+        let config = PlacementConfig {
+            spread: Some(vec![
+                SpreadRule {
+                    when_unsatisfiable: Some(WhenUnsatisfiable::DoNotSchedule),
+                    ..rule("topology.kubernetes.io/zone")
+                },
+                SpreadRule {
+                    when_unsatisfiable: Some(WhenUnsatisfiable::ScheduleAnyway),
+                    ..rule("topology.kubernetes.io/zone")
+                },
+            ]),
+        };
+        assert!(validate_placement(&config).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_positive_max_skew() {
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                max_skew: Some(0),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::InvalidMaxSkew { value: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_min_domains_without_a_hard_constraint() {
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                min_domains: Some(2),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::MinDomainsRequiresHardConstraint { index: 0 })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_positive_min_domains() {
+        let config = PlacementConfig {
+            spread: Some(vec![SpreadRule {
+                min_domains: Some(0),
+                when_unsatisfiable: Some(WhenUnsatisfiable::DoNotSchedule),
+                ..rule("topology.kubernetes.io/zone")
+            }]),
+        };
+        assert!(matches!(
+            validate_placement(&config),
+            Err(PlacementRejection::InvalidMinDomains { value: 0, .. })
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // Generated CRD schema
+    // ------------------------------------------------------------------
+    //
+    // The limits below are enforced by the API server from the generated
+    // schema, which is what makes them hold without an admission policy. The
+    // Rust validators above are only a backstop, so a dropped `#[schemars]`
+    // attribute would silently move enforcement from admission time to
+    // reconcile time with every unit test still green. These assertions run in
+    // CI with no cluster and catch exactly that.
+
+    /// Digs out the `placement` schema from a generated CRD.
+    fn placement_schema(crd: &serde_json::Value, path: &[&str]) -> serde_json::Value {
+        let mut node =
+            &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"];
+        for segment in path {
+            node = &node["properties"][segment];
+        }
+        node["properties"]["placement"].clone()
+    }
+
+    #[test]
+    fn generated_schema_enforces_the_spread_rule_cap() {
+        use kube::CustomResourceExt;
+
+        let crd = serde_json::to_value(crate::crd::Bind9Cluster::crd()).unwrap();
+        let placement = placement_schema(&crd, &["primary"]);
+
+        assert_eq!(
+            placement["properties"]["spread"]["maxItems"].as_u64(),
+            Some(crate::constants::MAX_SPREAD_RULES as u64),
+            "spread must carry maxItems so the API server rejects an over-long list"
+        );
+    }
+
+    #[test]
+    fn generated_schema_constrains_topology_key() {
+        use kube::CustomResourceExt;
+
+        let crd = serde_json::to_value(crate::crd::Bind9Instance::crd()).unwrap();
+        let placement = placement_schema(&crd, &[]);
+        let key = &placement["properties"]["spread"]["items"]["properties"]["topologyKey"];
+
+        // 253 prefix + '/' + 63 name.
+        assert_eq!(key["maxLength"].as_u64(), Some(317));
+        assert_eq!(key["minLength"].as_u64(), Some(1));
+        assert!(
+            key["pattern"].as_str().is_some_and(|p| !p.is_empty()),
+            "topologyKey must carry a charset pattern"
+        );
+    }
+
+    #[test]
+    fn generated_schema_carries_the_cross_field_cel_rules() {
+        use kube::CustomResourceExt;
+
+        let crd = serde_json::to_value(crate::crd::ClusterBind9Provider::crd()).unwrap();
+        let placement = placement_schema(&crd, &["secondary"]);
+        let rules = placement["properties"]["spread"]["items"]["x-kubernetes-validations"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+
+        let joined: String = rules
+            .iter()
+            .filter_map(|r| r["rule"].as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(
+            joined.contains("minDomains"),
+            "the minDomains/DoNotSchedule pairing must be enforced by CEL: {joined}"
+        );
+        assert!(
+            joined.contains("indexOf('/')"),
+            "the 253-character prefix cap must be enforced by CEL (RE2 has no lookahead): {joined}"
+        );
+    }
+
+    #[test]
+    fn generated_schema_bounds_numeric_fields() {
+        use kube::CustomResourceExt;
+
+        let crd = serde_json::to_value(crate::crd::Bind9Cluster::crd()).unwrap();
+        let item = placement_schema(&crd, &["primary"])["properties"]["spread"]["items"].clone();
+
+        assert_eq!(item["properties"]["maxSkew"]["minimum"].as_f64(), Some(1.0));
+        assert_eq!(
+            item["properties"]["minDomains"]["minimum"].as_f64(),
+            Some(1.0)
+        );
+        for (field, expected) in [
+            ("scope", vec!["Instance", "Role", "Cluster"]),
+            ("whenUnsatisfiable", vec!["DoNotSchedule", "ScheduleAnyway"]),
+        ] {
+            let got: Vec<&str> = item["properties"][field]["enum"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect();
+            assert_eq!(got, expected, "{field} must be a closed enum");
+        }
+    }
+}

--- a/src/reconcilers/bind9cluster/instances.rs
+++ b/src/reconcilers/bind9cluster/instances.rs
@@ -362,7 +362,7 @@ pub(super) async fn update_existing_managed_instances(
             // Backward compatibility: preserve deprecated rndc_secret_ref if set
             let updated_spec = Bind9InstanceSpec {
                 cluster_ref: instance.spec.cluster_ref.clone(),
-                role: instance.spec.role.clone(),
+                role: instance.spec.role,
                 replicas: instance.spec.replicas, // Preserve instance replicas (always 1 for managed)
                 version: common_spec.version.clone(),
                 image: common_spec.image.clone(),
@@ -374,6 +374,13 @@ pub(super) async fn update_existing_managed_instances(
                 rndc_secret_ref: instance.spec.rndc_secret_ref.clone(), // Preserve if set (deprecated)
                 rndc_key: instance.spec.rndc_key.clone(),               // Preserve if set
                 storage: instance.spec.storage.clone(),                 // Preserve if set
+                // Preserve any instance-level placement the user set directly.
+                // Cluster- and role-level placement is NOT copied down here:
+                // it is resolved against the live cluster when the Deployment
+                // is built (see `crate::placement::resolve_placement`), so a
+                // cluster-level change converges without rewriting every
+                // managed instance spec.
+                placement: instance.spec.placement.clone(),
                 bindcar_config: desired_bindcar_config,
             };
 
@@ -664,6 +671,7 @@ async fn create_managed_instance_with_owner(
         rndc_secret_ref: None, // Inherit from cluster/role config (deprecated)
         rndc_key: None,        // Inherit from cluster/role config
         storage: None,         // Use default (emptyDir)
+        placement: None,       // Inherit from role / cluster level at build time
         bindcar_config: common_spec
             .global
             .as_ref()

--- a/src/reconcilers/bind9cluster/status_helpers_tests.rs
+++ b/src/reconcilers/bind9cluster/status_helpers_tests.rs
@@ -48,6 +48,7 @@ mod tests {
                 ..Default::default()
             },
             spec: Bind9InstanceSpec {
+                placement: None,
                 cluster_ref: "test-cluster".to_string(),
                 role: ServerRole::Primary,
                 replicas: Some(1),

--- a/src/reconcilers/bind9instance/mod.rs
+++ b/src/reconcilers/bind9instance/mod.rs
@@ -399,24 +399,10 @@ pub async fn reconcile_bind9instance(ctx: Arc<Context>, instance: Bind9Instance)
 
         // Fetch deployment to check if it exists AND if OUR labels match
         let (deployment_exists, labels_match) = match deployment_api.get(&name).await {
-            Ok(deployment) => {
-                // Build desired labels from instance - these are the labels WE manage
-                let desired_labels =
-                    crate::bind9_resources::build_labels_from_instance(&name, &instance);
-
-                // Check if deployment has all OUR labels with correct values
-                // IMPORTANT: Only check labels we explicitly set via build_labels_from_instance()
-                // Other controllers or users may add additional labels - we don't care about those
-                let labels_match = if let Some(actual_labels) = &deployment.metadata.labels {
-                    desired_labels
-                        .iter()
-                        .all(|(key, value)| actual_labels.get(key) == Some(value))
-                } else {
-                    false // No labels at all = no match
-                };
-
-                (true, labels_match)
-            }
+            Ok(deployment) => (
+                true,
+                deployment_labels_are_current(&deployment, &name, &instance),
+            ),
             Err(_) => (false, false),
         };
 
@@ -665,6 +651,66 @@ pub async fn delete_bind9instance(ctx: Arc<Context>, instance: Bind9Instance) ->
 
     // Deletion is now handled by the finalizer in reconcile_bind9instance
     Ok(())
+}
+
+/// Whether a Deployment already carries every label the operator manages.
+///
+/// Used by the reconcile short-circuit: when this returns `false`, resource
+/// reconciliation runs even though nothing else looks stale.
+///
+/// Two label sets are checked, and the second is what makes an operator
+/// upgrade converge. `spec.selector` is immutable, so labels added after a
+/// Deployment exists can only go on the Pod template
+/// (`build_pod_labels_from_instance`, a superset of the metadata set). A
+/// Deployment created before topology spreading has correct *metadata* labels
+/// but no `bindy.firestoned.io/cluster` on its Pod template; checking metadata
+/// alone would let the short-circuit skip it forever, leaving it permanently
+/// without spread constraints.
+///
+/// Both checks are subset tests, not equality: other controllers, `kubectl`,
+/// and Helm add labels of their own, and those are none of our business.
+fn deployment_labels_are_current(
+    deployment: &Deployment,
+    name: &str,
+    instance: &Bind9Instance,
+) -> bool {
+    let desired_metadata = crate::bind9_resources::build_labels_from_instance(name, instance);
+    let metadata_matches = deployment.metadata.labels.as_ref().is_some_and(|actual| {
+        desired_metadata
+            .iter()
+            .all(|(key, value)| actual.get(key) == Some(value))
+    });
+
+    let desired_pod = crate::bind9_resources::build_pod_labels_from_instance(name, instance);
+    let pod_matches = deployment
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.metadata.as_ref())
+        .and_then(|m| m.labels.as_ref())
+        .is_some_and(|actual| {
+            desired_pod
+                .iter()
+                .all(|(key, value)| actual.get(key) == Some(value))
+        });
+
+    if metadata_matches && !pod_matches {
+        debug!(
+            "Deployment {name} Pod template labels are stale (missing operator-managed labels); \
+             reconciling resources"
+        );
+    }
+
+    metadata_matches && pod_matches
+}
+
+/// Test-only re-export of `deployment_labels_are_current`.
+#[cfg(test)]
+pub(crate) fn deployment_labels_are_current_for_test(
+    deployment: &Deployment,
+    name: &str,
+    instance: &Bind9Instance,
+) -> bool {
+    deployment_labels_are_current(deployment, name, instance)
 }
 
 #[cfg(test)]

--- a/src/reconcilers/bind9instance/mod_tests.rs
+++ b/src/reconcilers/bind9instance/mod_tests.rs
@@ -192,6 +192,7 @@ mod tests {
         let instance = Bind9Instance {
             metadata: ObjectMeta::default(),
             spec: Bind9InstanceSpec {
+                placement: None,
                 cluster_ref: String::new(),
                 role: ServerRole::Primary,
                 rndc_key: Some(RndcKeyConfig {
@@ -234,6 +235,7 @@ mod tests {
         let instance = Bind9Instance {
             metadata: ObjectMeta::default(),
             spec: Bind9InstanceSpec {
+                placement: None,
                 cluster_ref: String::new(),
                 role: ServerRole::Primary,
                 rndc_key: None,

--- a/src/reconcilers/bind9instance/resources.rs
+++ b/src/reconcilers/bind9instance/resources.rs
@@ -74,7 +74,7 @@ pub(super) fn resolve_full_rndc_config(
             return resolve_rndc_config_from_deprecated(
                 None,
                 deprecated_instance_ref,
-                instance.spec.role.clone(),
+                instance.spec.role,
             );
         }
     }
@@ -1011,7 +1011,61 @@ fn deployment_needs_update(current: &Deployment, desired: &Deployment) -> bool {
         return true;
     }
 
+    // Scheduling fields. Without this the operator would happily create a
+    // Deployment with topology spread constraints and then never reconcile a
+    // later change to them: every field below is absent from the comparison
+    // above, so `placement` edits would silently never reach a running
+    // Deployment.
+    let current_pod = current.spec.as_ref().and_then(|s| s.template.spec.as_ref());
+    let desired_pod = desired.spec.as_ref().and_then(|s| s.template.spec.as_ref());
+
+    if current_pod.and_then(|p| p.topology_spread_constraints.as_ref())
+        != desired_pod.and_then(|p| p.topology_spread_constraints.as_ref())
+    {
+        debug!("Pod topologySpreadConstraints changed");
+        return true;
+    }
+
+    // Pod template labels. `bindy.firestoned.io/cluster` is added here rather
+    // than in the (immutable) selector, so an operator upgrade has to be able
+    // to patch it onto Deployments that predate it.
+    let current_pod_labels = current
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.metadata.as_ref())
+        .and_then(|m| m.labels.as_ref());
+    let desired_pod_labels = desired
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.metadata.as_ref())
+        .and_then(|m| m.labels.as_ref());
+    if current_pod_labels != desired_pod_labels {
+        debug!("Pod template labels changed");
+        return true;
+    }
+
     false
+}
+
+/// Builds the `spec.template.spec` fragment that reconciles scheduling fields.
+///
+/// `topologySpreadConstraints` carries `patchMergeKey=topologyKey` +
+/// `patchStrategy=merge`, so sending a plain list MERGES it by key and stale
+/// constraints survive a removal. The `{"$patch": "replace"}` directive forces
+/// the whole list to be replaced; `null` deletes the field outright.
+fn build_placement_patch(desired: &Deployment) -> serde_json::Value {
+    let desired_pod = desired.spec.as_ref().and_then(|s| s.template.spec.as_ref());
+
+    let constraints = match desired_pod.and_then(|p| p.topology_spread_constraints.as_ref()) {
+        Some(list) => {
+            let mut items = vec![json!({"$patch": "replace"})];
+            items.extend(list.iter().map(|c| json!(c)));
+            json!(items)
+        }
+        None => json!(null),
+    };
+
+    json!({ "topologySpreadConstraints": constraints })
 }
 
 /// Create or update the Deployment for BIND9
@@ -1140,6 +1194,15 @@ async fn create_or_update_deployment(
             }
         }
     });
+
+    // Merge the scheduling fields into the same Pod spec fragment.
+    if let Some(pod_spec) = patch["spec"]["template"]["spec"].as_object_mut() {
+        if let Some(placement) = build_placement_patch(&deployment).as_object() {
+            for (key, value) in placement {
+                pod_spec.insert(key.clone(), value.clone());
+            }
+        }
+    }
 
     // Add metadata labels if present
     // NOTE: Strategic merge will update/add our labels but preserve any other labels
@@ -1340,6 +1403,22 @@ pub(super) async fn delete_resources(client: &Client, namespace: &str, name: &st
     Ok(())
 }
 
+/// Test-only re-exports of the private placement-convergence helpers.
+///
+/// Same rationale as `validate_user_pod_shape_for_test` below: these decide
+/// whether a live Deployment gets a scheduling change and how that change is
+/// expressed as a patch, so they need direct coverage — but they are not part
+/// of the production API surface.
+#[cfg(test)]
+pub(super) fn deployment_needs_update_for_test(current: &Deployment, desired: &Deployment) -> bool {
+    deployment_needs_update(current, desired)
+}
+
+#[cfg(test)]
+pub(super) fn build_placement_patch_for_test(desired: &Deployment) -> serde_json::Value {
+    build_placement_patch(desired)
+}
+
 /// Test-only re-export of the private `validate_user_pod_shape` helper.
 ///
 /// Tests live in a sibling `_tests.rs` module (per project convention) and
@@ -1404,6 +1483,37 @@ fn validate_user_pod_shape(
                 },
             )?;
         }
+    }
+
+    // Placement carries topology spreading only, so unlike volumes it is not a
+    // privilege-escalation surface — these are correctness checks. The CRD
+    // schema rejects most bad input at admission; this catches the rest, and
+    // anything reaching a cluster still running an older CRD revision.
+    // Validating every level, not just the winning one, means a user is told
+    // about a bad block even when a more specific block currently shadows it.
+    crate::placement::validate_optional_placement(instance.spec.placement.as_ref())
+        .with_context(|| format!("Bind9Instance {} spec.placement", instance.name_any()))?;
+    for (label, common) in [
+        (
+            cluster.map(|c| format!("Bind9Cluster {}", c.name_any())),
+            cluster.map(|c| &c.spec.common),
+        ),
+        (
+            cluster_provider.map(|p| format!("ClusterBind9Provider {}", p.name_any())),
+            cluster_provider.map(|p| &p.spec.common),
+        ),
+    ] {
+        let (Some(label), Some(common)) = (label, common) else {
+            continue;
+        };
+        crate::placement::validate_optional_placement(
+            common.primary.as_ref().and_then(|p| p.placement.as_ref()),
+        )
+        .with_context(|| format!("{label} spec.primary.placement"))?;
+        crate::placement::validate_optional_placement(
+            common.secondary.as_ref().and_then(|s| s.placement.as_ref()),
+        )
+        .with_context(|| format!("{label} spec.secondary.placement"))?;
     }
 
     // Instance-level fields.

--- a/src/reconcilers/bind9instance/resources_tests.rs
+++ b/src/reconcilers/bind9instance/resources_tests.rs
@@ -442,6 +442,7 @@ mod tests {
                 ..Default::default()
             },
             spec: Bind9InstanceSpec {
+                placement: None,
                 cluster_ref: String::new(),
                 role: ServerRole::Primary,
                 replicas: Some(1),
@@ -597,5 +598,472 @@ mod tests {
             msg.contains("Bind9Cluster tenant-a/malicious-cluster spec.volumes"),
             "{msg}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // validate_user_pod_shape — placement
+    // ------------------------------------------------------------------
+    //
+    // Placement is validated at EVERY level, not just the winning one, so a
+    // user is told about a bad block even while a more specific block shadows
+    // it. Without these, a bad role-level block on a cluster whose instance
+    // overrides placement would reconcile silently and only surface later.
+
+    mod placement_validation {
+        use super::{Bind9Cluster, Bind9ClusterCommonSpec, Bind9ClusterSpec, Bind9Instance};
+        use crate::crd::{PlacementConfig, PrimaryConfig, SecondaryConfig, SpreadRule};
+        use crate::reconcilers::bind9instance::resources::validate_user_pod_shape_for_test;
+
+        fn rule(topology_key: &str) -> SpreadRule {
+            SpreadRule {
+                topology_key: topology_key.into(),
+                max_skew: None,
+                when_unsatisfiable: None,
+                scope: None,
+                min_domains: None,
+                node_affinity_policy: None,
+                node_taints_policy: None,
+            }
+        }
+
+        fn bad_placement() -> PlacementConfig {
+            // Duplicate (topologyKey, whenUnsatisfiable): Kubernetes requires
+            // the pair to be unique and rejects the Pod outright.
+            PlacementConfig {
+                spread: Some(vec![
+                    rule("topology.kubernetes.io/zone"),
+                    rule("topology.kubernetes.io/zone"),
+                ]),
+            }
+        }
+
+        fn instance(placement: Option<PlacementConfig>) -> Bind9Instance {
+            let mut i = super::instance_with_volumes(vec![], vec![]);
+            i.spec.placement = placement;
+            i
+        }
+
+        fn cluster(common: Bind9ClusterCommonSpec) -> Bind9Cluster {
+            Bind9Cluster::new("my-dns", Bind9ClusterSpec { common })
+        }
+
+        fn empty_common() -> Bind9ClusterCommonSpec {
+            Bind9ClusterCommonSpec {
+                version: Some("9.18".into()),
+                primary: None,
+                secondary: None,
+                image: None,
+                config_map_refs: None,
+                global: None,
+                rndc_secret_refs: None,
+                acls: None,
+                volumes: None,
+                volume_mounts: None,
+            }
+        }
+
+        #[test]
+        fn accepts_a_valid_placement_block() {
+            let inst = instance(Some(PlacementConfig {
+                spread: Some(vec![rule("topology.kubernetes.io/zone")]),
+            }));
+            assert!(validate_user_pod_shape_for_test(&inst, None, None).is_ok());
+        }
+
+        #[test]
+        fn accepts_an_absent_placement_block() {
+            let inst = instance(None);
+            assert!(validate_user_pod_shape_for_test(&inst, None, None).is_ok());
+        }
+
+        #[test]
+        fn rejects_a_bad_instance_level_block() {
+            let inst = instance(Some(bad_placement()));
+            let err = validate_user_pod_shape_for_test(&inst, None, None)
+                .expect_err("duplicate spread rules must be rejected");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("spec.placement"),
+                "error must name the offending field: {msg}"
+            );
+        }
+
+        #[test]
+        fn rejects_a_bad_role_level_block_even_when_the_instance_overrides_it() {
+            // The instance sets its own (valid) placement, so the cluster block
+            // never reaches a Pod — but it is still wrong and the user should
+            // hear about it now rather than after an unrelated edit.
+            let inst = instance(Some(PlacementConfig {
+                spread: Some(vec![rule("topology.kubernetes.io/zone")]),
+            }));
+            let mut common = empty_common();
+            common.primary = Some(PrimaryConfig {
+                placement: Some(bad_placement()),
+                ..Default::default()
+            });
+            let c = cluster(common);
+
+            let err = validate_user_pod_shape_for_test(&inst, Some(&c), None)
+                .expect_err("a shadowed but invalid role block must still be rejected");
+            assert!(
+                format!("{err:#}").contains("spec.primary.placement"),
+                "error must name the role block: {err:#}"
+            );
+        }
+
+        #[test]
+        fn rejects_a_bad_secondary_block() {
+            let inst = instance(None);
+            let mut common = empty_common();
+            common.secondary = Some(SecondaryConfig {
+                placement: Some(bad_placement()),
+                ..Default::default()
+            });
+            let c = cluster(common);
+
+            let err = validate_user_pod_shape_for_test(&inst, Some(&c), None)
+                .expect_err("an invalid secondary block must be rejected");
+            assert!(
+                format!("{err:#}").contains("spec.secondary.placement"),
+                "error must name the role block: {err:#}"
+            );
+        }
+    }
+
+    // ==================================================================
+    // Placement convergence
+    // ==================================================================
+    //
+    // This is the machinery that decides whether a live Deployment gets a
+    // scheduling change at all, and how that change is expressed as a patch.
+    // It is the part most likely to break silently: a regression here does not
+    // fail loudly, it just leaves a running Deployment with stale constraints
+    // while every other test stays green.
+
+    mod placement_convergence {
+        use crate::bind9_resources::build_deployment;
+        use crate::crd::{
+            Bind9Cluster, Bind9ClusterCommonSpec, Bind9ClusterSpec, Bind9Instance,
+            Bind9InstanceSpec, PlacementConfig, PrimaryConfig, ServerRole, SpreadRule,
+            WhenUnsatisfiable,
+        };
+        use crate::reconcilers::bind9instance::deployment_labels_are_current_for_test as deployment_labels_are_current;
+        use crate::reconcilers::bind9instance::resources::{
+            build_placement_patch_for_test as build_placement_patch,
+            deployment_needs_update_for_test as deployment_needs_update,
+        };
+        use k8s_openapi::api::apps::v1::Deployment;
+        use kube::api::ObjectMeta;
+
+        fn instance(name: &str, cluster_ref: &str) -> Bind9Instance {
+            #[allow(deprecated)]
+            Bind9Instance {
+                metadata: ObjectMeta {
+                    name: Some(name.into()),
+                    namespace: Some("dns".into()),
+                    ..Default::default()
+                },
+                spec: Bind9InstanceSpec {
+                    cluster_ref: cluster_ref.to_string(),
+                    role: ServerRole::Primary,
+                    replicas: Some(1),
+                    version: Some("9.18".into()),
+                    image: None,
+                    config_map_refs: None,
+                    config: None,
+                    primary_servers: None,
+                    volumes: None,
+                    volume_mounts: None,
+                    rndc_secret_ref: None,
+                    rndc_key: None,
+                    storage: None,
+                    placement: None,
+                    bindcar_config: None,
+                },
+                status: None,
+            }
+        }
+
+        fn cluster(primaries: i32, placement: Option<PlacementConfig>) -> Bind9Cluster {
+            Bind9Cluster::new(
+                "my-dns",
+                Bind9ClusterSpec {
+                    common: Bind9ClusterCommonSpec {
+                        version: Some("9.18".into()),
+                        primary: Some(PrimaryConfig {
+                            replicas: Some(primaries),
+                            placement,
+                            ..Default::default()
+                        }),
+                        secondary: None,
+                        image: None,
+                        config_map_refs: None,
+                        global: None,
+                        rndc_secret_refs: None,
+                        acls: None,
+                        volumes: None,
+                        volume_mounts: None,
+                    },
+                },
+            )
+        }
+
+        fn deployment_for(cluster_spec: Option<&Bind9Cluster>) -> Deployment {
+            let inst = instance("my-dns-primary-0", "my-dns");
+            build_deployment(
+                "my-dns-primary-0",
+                "dns",
+                &inst,
+                cluster_spec,
+                None,
+                "rndc-key",
+            )
+        }
+
+        fn zone_rule(when: WhenUnsatisfiable) -> PlacementConfig {
+            PlacementConfig {
+                spread: Some(vec![SpreadRule {
+                    topology_key: "topology.kubernetes.io/zone".into(),
+                    max_skew: Some(1),
+                    when_unsatisfiable: Some(when),
+                    scope: None,
+                    min_domains: None,
+                    node_affinity_policy: None,
+                    node_taints_policy: None,
+                }]),
+            }
+        }
+
+        // ---------------- deployment_needs_update ----------------
+
+        #[test]
+        fn detects_a_constraint_being_added() {
+            // The upgrade case: a Deployment created before this feature has no
+            // constraints, and must be recognised as stale.
+            let current = deployment_for(Some(&cluster(1, None)));
+            let desired = deployment_for(Some(&cluster(3, None)));
+            assert!(current
+                .spec
+                .as_ref()
+                .unwrap()
+                .template
+                .spec
+                .as_ref()
+                .unwrap()
+                .topology_spread_constraints
+                .is_none());
+            assert!(deployment_needs_update(&current, &desired));
+        }
+
+        #[test]
+        fn detects_a_constraint_being_changed() {
+            let current = deployment_for(Some(&cluster(
+                3,
+                Some(zone_rule(WhenUnsatisfiable::ScheduleAnyway)),
+            )));
+            let desired = deployment_for(Some(&cluster(
+                3,
+                Some(zone_rule(WhenUnsatisfiable::DoNotSchedule)),
+            )));
+            assert!(deployment_needs_update(&current, &desired));
+        }
+
+        #[test]
+        fn detects_a_constraint_being_removed() {
+            // `spread: []` must be seen as a change, or the opt-out never takes.
+            let current = deployment_for(Some(&cluster(3, None)));
+            let desired = deployment_for(Some(&cluster(
+                3,
+                Some(PlacementConfig {
+                    spread: Some(vec![]),
+                }),
+            )));
+            assert!(deployment_needs_update(&current, &desired));
+        }
+
+        #[test]
+        fn detects_stale_pod_template_labels() {
+            let desired = deployment_for(Some(&cluster(3, None)));
+            let mut current = desired.clone();
+            current
+                .spec
+                .as_mut()
+                .unwrap()
+                .template
+                .metadata
+                .as_mut()
+                .unwrap()
+                .labels
+                .as_mut()
+                .unwrap()
+                .remove("bindy.firestoned.io/cluster");
+            assert!(
+                deployment_needs_update(&current, &desired),
+                "a Deployment missing the cluster Pod label must be reconciled"
+            );
+        }
+
+        #[test]
+        fn reports_no_update_when_nothing_changed() {
+            // Guards against a hot-patch loop: if this ever returns true for an
+            // unchanged pair, the operator rewrites the Deployment on every
+            // reconcile and rolls the DNS pods every five minutes.
+            let c = cluster(3, Some(zone_rule(WhenUnsatisfiable::DoNotSchedule)));
+            let current = deployment_for(Some(&c));
+            let desired = deployment_for(Some(&c));
+            assert!(!deployment_needs_update(&current, &desired));
+        }
+
+        // ---------------- build_placement_patch ----------------
+
+        #[test]
+        fn patch_replaces_rather_than_merges_the_constraint_list() {
+            // topologySpreadConstraints has patchStrategy=merge with
+            // patchMergeKey=topologyKey. Without the `$patch: replace`
+            // directive, a strategic merge patch MERGES by key and a removed
+            // constraint survives on the live Deployment.
+            let desired = deployment_for(Some(&cluster(3, None)));
+            let patch = build_placement_patch(&desired);
+            let list = patch["topologySpreadConstraints"].as_array().unwrap();
+
+            assert_eq!(
+                list[0],
+                serde_json::json!({"$patch": "replace"}),
+                "the replace directive must be the first element"
+            );
+            assert_eq!(list.len(), 2, "directive + one generated constraint");
+            assert_eq!(
+                list[1]["topologyKey"].as_str(),
+                Some("topology.kubernetes.io/zone")
+            );
+        }
+
+        #[test]
+        fn patch_nulls_the_field_when_no_constraints_are_desired() {
+            // This is the removal path. Sending an empty list would leave the
+            // field present-but-empty; only an explicit null deletes it.
+            let desired = deployment_for(Some(&cluster(
+                3,
+                Some(PlacementConfig {
+                    spread: Some(vec![]),
+                }),
+            )));
+            let patch = build_placement_patch(&desired);
+            assert!(
+                patch["topologySpreadConstraints"].is_null(),
+                "removal must send null, got {}",
+                patch["topologySpreadConstraints"]
+            );
+        }
+
+        #[test]
+        fn patch_carries_every_rule_in_order() {
+            let mut config = zone_rule(WhenUnsatisfiable::DoNotSchedule);
+            config.spread.as_mut().unwrap().push(SpreadRule {
+                topology_key: "kubernetes.io/hostname".into(),
+                max_skew: Some(1),
+                when_unsatisfiable: Some(WhenUnsatisfiable::ScheduleAnyway),
+                scope: None,
+                min_domains: None,
+                node_affinity_policy: None,
+                node_taints_policy: None,
+            });
+
+            let desired = deployment_for(Some(&cluster(3, Some(config))));
+            let list = build_placement_patch(&desired)["topologySpreadConstraints"]
+                .as_array()
+                .unwrap()
+                .clone();
+
+            assert_eq!(list.len(), 3, "directive + two rules");
+            assert_eq!(
+                list[1]["topologyKey"].as_str(),
+                Some("topology.kubernetes.io/zone")
+            );
+            assert_eq!(
+                list[2]["topologyKey"].as_str(),
+                Some("kubernetes.io/hostname")
+            );
+        }
+
+        // ---------------- reconcile short-circuit ----------------
+
+        #[test]
+        fn label_check_passes_for_a_freshly_built_deployment() {
+            let inst = instance("my-dns-primary-0", "my-dns");
+            let deployment = deployment_for(Some(&cluster(3, None)));
+            assert!(deployment_labels_are_current(
+                &deployment,
+                "my-dns-primary-0",
+                &inst
+            ));
+        }
+
+        #[test]
+        fn label_check_fails_when_the_pod_template_predates_the_feature() {
+            // THE upgrade regression. Metadata labels are correct (they never
+            // changed), only the Pod template lacks the cluster label. Checking
+            // metadata alone would skip this Deployment forever.
+            let inst = instance("my-dns-primary-0", "my-dns");
+            let mut deployment = deployment_for(Some(&cluster(3, None)));
+            deployment
+                .spec
+                .as_mut()
+                .unwrap()
+                .template
+                .metadata
+                .as_mut()
+                .unwrap()
+                .labels
+                .as_mut()
+                .unwrap()
+                .remove("bindy.firestoned.io/cluster");
+
+            assert!(
+                !deployment_labels_are_current(&deployment, "my-dns-primary-0", &inst),
+                "stale Pod template labels must force reconciliation"
+            );
+        }
+
+        #[test]
+        fn label_check_tolerates_foreign_labels() {
+            // Other controllers, kubectl and Helm add labels of their own; the
+            // check is a subset test, not equality.
+            let inst = instance("my-dns-primary-0", "my-dns");
+            let mut deployment = deployment_for(Some(&cluster(3, None)));
+            for target in [
+                deployment.metadata.labels.as_mut().unwrap(),
+                deployment
+                    .spec
+                    .as_mut()
+                    .unwrap()
+                    .template
+                    .metadata
+                    .as_mut()
+                    .unwrap()
+                    .labels
+                    .as_mut()
+                    .unwrap(),
+            ] {
+                target.insert("argocd.argoproj.io/instance".into(), "someapp".into());
+            }
+            assert!(deployment_labels_are_current(
+                &deployment,
+                "my-dns-primary-0",
+                &inst
+            ));
+        }
+
+        #[test]
+        fn label_check_fails_when_a_deployment_has_no_labels_at_all() {
+            let inst = instance("my-dns-primary-0", "my-dns");
+            let mut deployment = deployment_for(Some(&cluster(3, None)));
+            deployment.metadata.labels = None;
+            assert!(!deployment_labels_are_current(
+                &deployment,
+                "my-dns-primary-0",
+                &inst
+            ));
+        }
     }
 }

--- a/src/reconcilers/clusterbind9provider_tests.rs
+++ b/src/reconcilers/clusterbind9provider_tests.rs
@@ -150,6 +150,7 @@ mod tests {
                 ..Default::default()
             },
             spec: Bind9InstanceSpec {
+                placement: None,
                 cluster_ref: "test-global-cluster".to_string(),
                 role: ServerRole::Primary,
                 replicas: Some(1),

--- a/tests/multi_tenancy_integration.rs
+++ b/tests/multi_tenancy_integration.rs
@@ -370,6 +370,7 @@ async fn create_instance(
             ..Default::default()
         },
         spec: bindy::crd::Bind9InstanceSpec {
+            placement: None,
             cluster_ref: cluster_ref.to_string(),
             role,
             replicas: Some(1),

--- a/tests/simple_integration.rs
+++ b/tests/simple_integration.rs
@@ -606,6 +606,7 @@ async fn test_bind9instance_create_read_delete() {
             ..Default::default()
         },
         spec: Bind9InstanceSpec {
+            placement: None,
             cluster_ref: cluster_ref.to_string(),
             role: ServerRole::Primary,
             replicas: Some(1),
@@ -1142,6 +1143,7 @@ async fn test_instance_pod_label_selector_finds_pods() {
             ..Default::default()
         },
         spec: Bind9InstanceSpec {
+            placement: None,
             cluster_ref: cluster_name.to_string(),
             role: ServerRole::Primary,
             replicas: Some(1),

--- a/tests/zone_spread_test.sh
+++ b/tests/zone_spread_test.sh
@@ -1,0 +1,524 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# End-to-end verification of `spec.placement` zone spreading, against a kind
+# cluster faking a three-zone region (deploy/kind-config-multizone.yaml).
+#
+# The interesting assertion is not "pods ended up in different zones". The
+# scheduler's default scoring will often achieve that on its own, so a passing
+# spread proves nothing by itself and is not a contract when the default rule
+# is soft. What this script actually proves is:
+#
+#   1. The generated constraint's labelSelector matches the SIBLING primaries,
+#      not just the Deployment's own single Pod. With a per-instance selector
+#      the balanced set would have size 1 and the constraint would be a no-op.
+#   2. A hard constraint is genuinely enforced: with two of three zones
+#      cordoned, the extra primaries must go Pending with a topology-spread
+#      reason. That can only happen if (1) holds.
+#   3. spec.selector stays free of the cluster label, since it is immutable.
+#   4. Changes to placement converge onto existing Deployments — including
+#      REMOVALS, which is where strategic merge patch is easy to get wrong.
+#   5. The automatic default covers primaries ONLY. Secondaries keep whatever
+#      scheduling they had until they opt in, so upgrading the operator does
+#      not silently move running secondary workloads.
+#   6. The generated CRD schema rejects invalid rules on its own, with no
+#      ValidatingAdmissionPolicy installed.
+#
+# Self-contained by default: creates its own kind cluster, installs the CRDs
+# and RBAC, and deploys the operator. Requires only kind, kubectl and docker.
+#
+# Usage:
+#   ./tests/zone_spread_test.sh                      # build image, full setup
+#   ./tests/zone_spread_test.sh --image REF          # use a prebuilt image
+#   ./tests/zone_spread_test.sh --skip-deploy        # reuse a running setup
+#   KEEP_CLUSTER=1 ./tests/zone_spread_test.sh       # leave the cluster up
+
+set -euo pipefail
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CLUSTER_NAME="${CLUSTER_NAME:=bindy-zonespread}"
+NAMESPACE="${NAMESPACE:=bindy-system}"
+DNS_CLUSTER="${DNS_CLUSTER:=zonespread}"
+KEEP_CLUSTER="${KEEP_CLUSTER:=}"
+PRIMARIES=3
+
+# Always address the cluster explicitly. Relying on the ambient context makes
+# the script destructive if someone's kubeconfig points at production.
+KUBECTL="kubectl --context kind-${CLUSTER_NAME}"
+
+IMAGE_REF=""
+SKIP_DEPLOY=false
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --image) IMAGE_REF="$2"; shift 2 ;;
+    --skip-deploy) SKIP_DEPLOY=true; shift ;;
+    *) echo -e "${RED}Unknown option: $1${NC}"; echo "Usage: $0 [--image REF] [--skip-deploy]"; exit 1 ;;
+  esac
+done
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; exit 1; }
+info() { echo -e "${YELLOW}▸${NC} $1"; }
+warn() { echo -e "${YELLOW}!${NC} $1"; }
+step() { echo -e "${BLUE}==>${NC} $1"; }
+
+# `repeat <char> <count>` — avoids a python3 dependency for the long-key cases.
+repeat() { printf "%*s" "$2" '' | tr ' ' "$1"; }
+
+# The Deployment metadata keeps its original label set; the cluster label lives
+# on the POD TEMPLATE only (spec.selector is immutable). So Deployments are
+# listed by name, not by selector.
+primary_deployments() {
+  ${KUBECTL} get deploy -n "${NAMESPACE}" -o name 2>/dev/null \
+    | sed 's|^deployment.apps/||' \
+    | grep "^${DNS_CLUSTER}-primary-" || true
+}
+
+primary_pods_jsonpath() {
+  ${KUBECTL} get pods -n "${NAMESPACE}" \
+    -l "bindy.firestoned.io/cluster=${DNS_CLUSTER},bindy.firestoned.io/role=primary" \
+    "$@" 2>/dev/null || true
+}
+
+cleanup() {
+  local rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo
+    warn "Failing — cluster diagnostics:"
+    ${KUBECTL} get pods -n "${NAMESPACE}" -o wide 2>/dev/null | head -20 || true
+    ${KUBECTL} get events -n "${NAMESPACE}" --field-selector reason=FailedScheduling \
+      -o jsonpath='{range .items[*]}{.message}{"\n"}{end}' 2>/dev/null | sort -u | head -5 || true
+  fi
+  info "Cleaning up"
+  ${KUBECTL} uncordon -l topology.kubernetes.io/zone >/dev/null 2>&1 || true
+  # Wait for the delete: managed Bind9Instances carry finalizers, and leaving
+  # them mid-deletion makes an immediately-following run race its own leftovers.
+  ${KUBECTL} delete bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" \
+    --ignore-not-found --timeout=120s >/dev/null 2>&1 || true
+  if [ "${SKIP_DEPLOY}" = false ] && [ -z "${KEEP_CLUSTER}" ]; then
+    kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# ==========================================================================
+# Setup
+# ==========================================================================
+
+if [ "${SKIP_DEPLOY}" = false ]; then
+  for bin in kind kubectl; do
+    command -v "${bin}" >/dev/null 2>&1 || fail "${bin} not found on PATH"
+  done
+
+  if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    step "Reusing existing kind cluster ${CLUSTER_NAME}"
+  else
+    step "Creating three-zone kind cluster ${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}" \
+      --config "${PROJECT_ROOT}/deploy/kind-config-multizone.yaml" \
+      || fail "failed to create kind cluster"
+  fi
+
+  ${KUBECTL} wait --for=condition=Ready node --all --timeout=180s >/dev/null \
+    || fail "nodes did not become Ready"
+
+  step "Installing CRDs"
+  # --server-side: the cluster CRDs exceed the 256KB last-applied-configuration
+  # annotation that client-side apply relies on.
+  ${KUBECTL} apply --server-side --force-conflicts \
+    -f "${PROJECT_ROOT}/deploy/operator/crds/" >/dev/null \
+    || fail "failed to install CRDs"
+
+  step "Creating namespace and RBAC"
+  ${KUBECTL} create namespace "${NAMESPACE}" --dry-run=client -o yaml | ${KUBECTL} apply -f - >/dev/null
+  ${KUBECTL} apply -f "${PROJECT_ROOT}/deploy/operator/rbac/" >/dev/null
+
+  if [ -z "${IMAGE_REF}" ]; then
+    command -v docker >/dev/null 2>&1 || fail "docker not found (pass --image to use a prebuilt operator image)"
+    # Use the repo's own local build path rather than `docker build .`:
+    # docker/Dockerfile consumes pre-built binaries from binaries/<arch>/ and
+    # cannot build from source. `build-docker-fast.sh local` cross-compiles a
+    # Linux binary with cargo and wraps it in docker/Dockerfile.local.
+    step "Building operator image (scripts/build-docker-fast.sh local)"
+    "${PROJECT_ROOT}/scripts/build-docker-fast.sh" local zonespread \
+      || fail "image build failed. Cross-compiling to Linux needs the target toolchain \
+(rustup target add ${LINUX_TARGET:-x86_64-unknown-linux-gnu} plus a linker); \
+on a machine without it, pass --image REF with a prebuilt operator image."
+    IMAGE_REF="${REGISTRY:-ghcr.io}/firestoned/bindy:zonespread"
+  fi
+
+  if docker image inspect "${IMAGE_REF}" >/dev/null 2>&1; then
+    step "Loading ${IMAGE_REF} into kind"
+    kind load docker-image "${IMAGE_REF}" --name "${CLUSTER_NAME}" >/dev/null
+  else
+    warn "${IMAGE_REF} not in local docker; assuming the kind node can pull it"
+  fi
+
+  step "Deploying operator (${IMAGE_REF})"
+  sed "s|ghcr.io/firestoned/bindy:latest|${IMAGE_REF}|g" \
+    "${PROJECT_ROOT}/deploy/operator/deployment.yaml" | ${KUBECTL} apply -f - >/dev/null
+
+  ${KUBECTL} wait --for=condition=available --timeout=300s \
+    deployment/bindy -n "${NAMESPACE}" || {
+      ${KUBECTL} logs -n "${NAMESPACE}" -l app=bindy --tail=50 || true
+      fail "operator failed to become available"
+    }
+  pass "operator running"
+else
+  info "Skipping setup; using the running cluster ${CLUSTER_NAME}"
+  ${KUBECTL} get nodes >/dev/null 2>&1 || fail "cluster ${CLUSTER_NAME} is not reachable"
+fi
+
+echo
+
+# Start from a clean slate: a previous (or interrupted) run may still be
+# tearing down instances of the same name.
+info "Waiting for any previous ${DNS_CLUSTER} resources to finish deleting"
+${KUBECTL} delete bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" \
+  --ignore-not-found --timeout=120s >/dev/null 2>&1 || true
+leftover=0; stale_pods=0
+for _ in $(seq 1 90); do
+  leftover=$(${KUBECTL} get bind9instance -n "${NAMESPACE}" \
+    -l "bindy.firestoned.io/cluster=${DNS_CLUSTER}" -o name 2>/dev/null | wc -l | tr -d ' ')
+  stale_pods=$(primary_pods_jsonpath -o name | wc -l | tr -d ' ')
+  [ "${leftover}" -eq 0 ] && [ "${stale_pods}" -eq 0 ] && break
+  sleep 2
+done
+[ "${leftover}" -eq 0 ] && [ "${stale_pods}" -eq 0 ] \
+  || fail "previous ${DNS_CLUSTER} resources still terminating (${leftover} instances, ${stale_pods} pods)"
+
+# --------------------------------------------------------------------------
+info "Checking the cluster really has three zones"
+# --------------------------------------------------------------------------
+ZONES=()
+while IFS= read -r z; do
+  [ -n "${z}" ] && ZONES+=("${z}")
+done < <(${KUBECTL} get nodes \
+  -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}{end}' \
+  | tr ' ' '\n' | grep -v '^$' | sort -u || true)
+
+if [ "${#ZONES[@]}" -lt 3 ]; then
+  found="none"; [ "${#ZONES[@]}" -gt 0 ] && found="${ZONES[*]}"
+  fail "need at least 3 zones, found ${#ZONES[@]}: ${found}. Use deploy/kind-config-multizone.yaml"
+fi
+pass "found ${#ZONES[@]} zones: ${ZONES[*]}"
+
+# --------------------------------------------------------------------------
+info "Creating a ${PRIMARIES}-primary Bind9Cluster with no placement block (tests the DEFAULT)"
+# --------------------------------------------------------------------------
+${KUBECTL} apply -f - >/dev/null <<EOF
+apiVersion: bindy.firestoned.io/v1beta1
+kind: Bind9Cluster
+metadata:
+  name: ${DNS_CLUSTER}
+  namespace: ${NAMESPACE}
+spec:
+  version: "9.18"
+  primary:
+    replicas: ${PRIMARIES}
+EOF
+
+running=0
+for _ in $(seq 1 60); do
+  # Distinct owning instances, not raw Pods: a Pod mid-rollout or
+  # mid-termination would otherwise be double-counted.
+  running=$(primary_pods_jsonpath --field-selector=status.phase=Running \
+    -o jsonpath='{range .items[*]}{.metadata.labels.app\.kubernetes\.io/instance}{"\n"}{end}' \
+    | grep -v '^$' | sort -u | wc -l | tr -d ' ' || true)
+  [ "${running}" -ge "${PRIMARIES}" ] && break
+  sleep 5
+done
+[ "${running}" -ge "${PRIMARIES}" ] || fail "only ${running}/${PRIMARIES} primary instances have a running pod"
+pass "${running} primary instances have a running pod"
+
+# --------------------------------------------------------------------------
+info "TEST 1: the constraint's selector spans sibling Deployments"
+# --------------------------------------------------------------------------
+DEPLOY="${DNS_CLUSTER}-primary-0"
+SELECTOR=$(${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" \
+  -o jsonpath='{.spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels}')
+[ -n "${SELECTOR}" ] || fail "no topologySpreadConstraints on ${DEPLOY} (the default should have applied)"
+
+echo "${SELECTOR}" | grep -q "bindy.firestoned.io/cluster" \
+  || fail "constraint selector lacks the cluster label; it would balance a set of one: ${SELECTOR}"
+echo "${SELECTOR}" | grep -q "bindy.firestoned.io/role" \
+  || fail "constraint selector lacks the role label: ${SELECTOR}"
+echo "${SELECTOR}" | grep -q "app.kubernetes.io/instance" \
+  && fail "constraint selector is per-instance; it would spread nothing: ${SELECTOR}"
+pass "selector is cross-instance: ${SELECTOR}"
+
+MATCHED_INSTANCES=$(primary_pods_jsonpath \
+  -o jsonpath='{range .items[*]}{.metadata.labels.app\.kubernetes\.io/instance}{"\n"}{end}' \
+  | grep -v '^$' | sort -u | wc -l | tr -d ' ' || true)
+[ "${MATCHED_INSTANCES}" -eq "${PRIMARIES}" ] \
+  || fail "constraint selector spans ${MATCHED_INSTANCES} instance(s), expected ${PRIMARIES}"
+pass "selector spans all ${MATCHED_INSTANCES} sibling primary Deployments"
+
+# --------------------------------------------------------------------------
+info "TEST 2: spec.selector does NOT carry the cluster label (it is immutable)"
+# --------------------------------------------------------------------------
+${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" -o jsonpath='{.spec.selector.matchLabels}' \
+  | grep -q "bindy.firestoned.io/cluster" \
+  && fail "cluster label leaked into the immutable spec.selector; upgrades of existing Deployments would fail"
+pass "spec.selector unchanged; the new label lives on the Pod template only"
+
+# --------------------------------------------------------------------------
+info "TEST 3: zone occupancy under the SOFT default (informational)"
+# --------------------------------------------------------------------------
+# Deliberately not a hard assertion. The default rule is ScheduleAnyway, so
+# even distribution is scheduler scoring, not a contract — asserting on it
+# would make this suite flaky under unrelated cluster pressure. TEST 5 makes
+# the contractual claim, using a hard constraint.
+USED_ZONES=$(primary_pods_jsonpath --field-selector=status.phase=Running \
+  -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
+  | grep -v '^$' | sort -u \
+  | while read -r n; do
+      ${KUBECTL} get node "${n}" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}' 2>/dev/null
+    done | sort -u | grep -c . || true)
+if [ "${USED_ZONES}" -ge 3 ]; then
+  pass "primaries occupy ${USED_ZONES} distinct zones"
+else
+  warn "primaries occupy only ${USED_ZONES} zone(s); the soft default does not guarantee more (not a failure)"
+fi
+
+# --------------------------------------------------------------------------
+info "TEST 4: placement changes converge onto EXISTING Deployments"
+# --------------------------------------------------------------------------
+${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" --type=merge -p '{
+  "spec": {"primary": {"placement": {"spread": [
+    {"topologyKey": "topology.kubernetes.io/zone", "maxSkew": 1,
+     "whenUnsatisfiable": "DoNotSchedule", "minDomains": 3}]}}}}' >/dev/null
+
+# Wait for EVERY primary Deployment, not just the first. TEST 5 is only
+# meaningful once all of them carry the hard constraint: a single primary still
+# running the soft rule can fill the one schedulable zone, leaving nothing
+# Pending and silently passing a test that proves nothing.
+converged=0
+for _ in $(seq 1 90); do
+  converged=0
+  for d in $(primary_deployments); do
+    got=$(${KUBECTL} get deploy "${d}" -n "${NAMESPACE}" \
+      -o jsonpath='{.spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable}' 2>/dev/null)
+    [ "${got}" = "DoNotSchedule" ] && converged=$((converged + 1))
+  done
+  [ "${converged}" -eq "${PRIMARIES}" ] && break
+  sleep 2
+done
+[ "${converged}" -eq "${PRIMARIES}" ] \
+  || fail "only ${converged}/${PRIMARIES} primary Deployments converged to the hard constraint"
+
+# Wait for the rollouts, so no Pod from a previous ReplicaSet (still carrying
+# the old soft rule) is occupying a zone when TEST 5 runs. A rollout that never
+# completes is a real failure, not something to shrug off.
+for d in $(primary_deployments); do
+  ${KUBECTL} rollout status "deploy/${d}" -n "${NAMESPACE}" --timeout=180s >/dev/null \
+    || fail "rollout of ${d} did not complete after the placement change"
+done
+pass "all ${PRIMARIES} primary Deployments converged to whenUnsatisfiable=DoNotSchedule"
+
+# --------------------------------------------------------------------------
+info "TEST 5: the hard constraint is genuinely ENFORCED"
+# --------------------------------------------------------------------------
+# Cordon every zone but the first. With maxSkew 1 and one schedulable zone, at
+# most ONE primary may run: the others must go Pending. With a per-instance
+# selector every Pod would happily schedule instead.
+for z in "${ZONES[@]:1}"; do
+  ${KUBECTL} cordon -l "topology.kubernetes.io/zone=${z}" >/dev/null
+done
+primary_pods_jsonpath -o name | xargs -r -n1 ${KUBECTL} delete -n "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+
+PENDING=0
+for _ in $(seq 1 30); do
+  PENDING=$(primary_pods_jsonpath --field-selector=status.phase=Pending -o name | wc -l | tr -d ' ')
+  [ "${PENDING}" -ge 2 ] && break
+  sleep 5
+done
+if [ "${PENDING}" -lt 2 ]; then
+  echo "--- diagnostic: primary pods ---"
+  primary_pods_jsonpath -o wide | head
+  echo "--- diagnostic: constraints per Deployment ---"
+  for d in $(primary_deployments); do
+    echo -n "${d}  "
+    ${KUBECTL} get deploy "${d}" -n "${NAMESPACE}" \
+      -o jsonpath='{.spec.template.spec.topologySpreadConstraints}{"\n"}' 2>&1
+  done
+  fail "expected >=2 Pending primaries with only one schedulable zone, got ${PENDING}"
+fi
+
+# Events lag behind the scheduling decision, so poll rather than sampling once.
+spread_cited=""
+for _ in $(seq 1 30); do
+  if ${KUBECTL} get events -n "${NAMESPACE}" --field-selector reason=FailedScheduling \
+       -o jsonpath='{range .items[*]}{.message}{"\n"}{end}' 2>/dev/null \
+       | grep -q "topology spread constraints"; then
+    spread_cited=yes; break
+  fi
+  sleep 3
+done
+if [ -z "${spread_cited}" ]; then
+  echo "--- diagnostic: FailedScheduling messages ---"
+  ${KUBECTL} get events -n "${NAMESPACE}" --field-selector reason=FailedScheduling \
+    -o jsonpath='{range .items[*]}{.message}{"\n"}{end}' 2>&1 | sort -u | head -5
+  fail "pods are Pending but not for a topology-spread reason"
+fi
+pass "${PENDING} primaries Pending, scheduler cites topology spread constraints"
+
+for z in "${ZONES[@]:1}"; do
+  ${KUBECTL} uncordon -l "topology.kubernetes.io/zone=${z}" >/dev/null
+done
+
+# --------------------------------------------------------------------------
+info "TEST 6: removing placement removes the constraint (strategic-merge removal)"
+# --------------------------------------------------------------------------
+${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" --type=merge -p '{
+  "spec": {"primary": {"placement": {"spread": []}}}}' >/dev/null
+
+tsc="unset"
+for _ in $(seq 1 40); do
+  tsc=$(${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" \
+    -o jsonpath='{.spec.template.spec.topologySpreadConstraints}' 2>/dev/null)
+  [ -z "${tsc}" ] && break
+  sleep 2
+done
+[ -z "${tsc}" ] || fail "constraints survived the opt-out; strategic merge merged instead of replacing: ${tsc}"
+pass "constraints removed by 'spread: []'"
+
+# --------------------------------------------------------------------------
+info "TEST 7: a Deployment predating this feature is upgraded in place"
+# --------------------------------------------------------------------------
+# Simulate the operator-upgrade case by stripping the Pod-template label and
+# the constraints from a live Deployment, leaving the (immutable) spec.selector
+# alone. The operator must repair it WITHOUT touching spec.selector — a widened
+# selector would be rejected as immutable and wedge the reconciler.
+${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" --type=merge \
+  -p '{"spec": {"primary": {"placement": null}}}' >/dev/null
+for _ in $(seq 1 40); do
+  tsc=$(${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" \
+    -o jsonpath='{.spec.template.spec.topologySpreadConstraints}' 2>/dev/null)
+  [ -n "${tsc}" ] && break
+  sleep 2
+done
+[ -n "${tsc}" ] || fail "default spread did not come back after clearing placement"
+
+SELECTOR_BEFORE=$(${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" -o jsonpath='{.spec.selector.matchLabels}')
+
+${KUBECTL} patch deploy "${DEPLOY}" -n "${NAMESPACE}" --type=json -p '[
+  {"op":"remove","path":"/spec/template/spec/topologySpreadConstraints"},
+  {"op":"remove","path":"/spec/template/metadata/labels/bindy.firestoned.io~1cluster"}]' >/dev/null
+
+for _ in $(seq 1 40); do
+  tsc=$(${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" \
+    -o jsonpath='{.spec.template.spec.topologySpreadConstraints}' 2>/dev/null)
+  [ -n "${tsc}" ] && break
+  sleep 2
+done
+[ -n "${tsc}" ] || fail "stale Deployment was never repaired; the reconcile short-circuit skipped it"
+
+SELECTOR_AFTER=$(${KUBECTL} get deploy "${DEPLOY}" -n "${NAMESPACE}" -o jsonpath='{.spec.selector.matchLabels}')
+[ "${SELECTOR_BEFORE}" = "${SELECTOR_AFTER}" ] \
+  || fail "spec.selector changed during repair (immutable field): '${SELECTOR_BEFORE}' -> '${SELECTOR_AFTER}'"
+pass "stale Deployment repaired in place, spec.selector untouched"
+
+# --------------------------------------------------------------------------
+info "TEST 8: secondaries get NO default, and can opt in"
+# --------------------------------------------------------------------------
+# Defaulting secondaries would silently change where already-running secondary
+# Pods schedule the moment an operator is upgraded. They must stay untouched
+# until asked.
+${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" --type=merge \
+  -p '{"spec": {"secondary": {"replicas": 3}}}' >/dev/null
+
+SEC_DEPLOY="${DNS_CLUSTER}-secondary-0"
+for _ in $(seq 1 60); do
+  ${KUBECTL} get deploy "${SEC_DEPLOY}" -n "${NAMESPACE}" >/dev/null 2>&1 && break
+  sleep 5
+done
+${KUBECTL} get deploy "${SEC_DEPLOY}" -n "${NAMESPACE}" >/dev/null 2>&1 \
+  || fail "secondary Deployment ${SEC_DEPLOY} was never created"
+
+# Wait for the operator to finish with the secondary rather than sleeping a
+# fixed interval: the rollout completing means it has been fully reconciled, so
+# a constraint appearing later would be a real regression, not a race.
+${KUBECTL} rollout status "deploy/${SEC_DEPLOY}" -n "${NAMESPACE}" --timeout=180s >/dev/null \
+  || fail "secondary Deployment never rolled out"
+
+# Then hold the negative for a few reconcile ticks, failing fast if one appears.
+for _ in $(seq 1 10); do
+  sec_tsc=$(${KUBECTL} get deploy "${SEC_DEPLOY}" -n "${NAMESPACE}" \
+    -o jsonpath='{.spec.template.spec.topologySpreadConstraints}' 2>/dev/null)
+  [ -z "${sec_tsc}" ] \
+    || fail "secondaries received an automatic spread constraint; that is an unannounced scheduling change on upgrade: ${sec_tsc}"
+  sleep 2
+done
+pass "secondaries have no constraint by default"
+
+${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" --type=merge -p '{
+  "spec": {"secondary": {"placement": {"spread": [
+    {"topologyKey": "topology.kubernetes.io/zone", "maxSkew": 1,
+     "whenUnsatisfiable": "ScheduleAnyway"}]}}}}' >/dev/null
+
+sec_tsc=""
+for _ in $(seq 1 40); do
+  sec_tsc=$(${KUBECTL} get deploy "${SEC_DEPLOY}" -n "${NAMESPACE}" \
+    -o jsonpath='{.spec.template.spec.topologySpreadConstraints}' 2>/dev/null)
+  [ -n "${sec_tsc}" ] && break
+  sleep 2
+done
+[ -n "${sec_tsc}" ] || fail "secondary opt-in did not take effect"
+echo "${sec_tsc}" | grep -q '"bindy.firestoned.io/role":"secondary"' \
+  || fail "secondary constraint selects the wrong role: ${sec_tsc}"
+pass "secondaries opt in explicitly, selecting sibling secondaries"
+
+# --------------------------------------------------------------------------
+info "TEST 9: the CRD schema rejects invalid rules WITHOUT an admission policy"
+# --------------------------------------------------------------------------
+# These limits are structural (maxItems / pattern / minimum /
+# x-kubernetes-validations), so they hold on any cluster with the CRDs
+# installed — no optional ValidatingAdmissionPolicy required.
+${KUBECTL} get validatingadmissionpolicy 2>/dev/null | grep -q placement \
+  && fail "a placement admission policy is installed; TEST 9 would not prove schema enforcement"
+
+schema_reject() {
+  local desc="$1" patch="$2"
+  if ${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" \
+       --type=merge -p "${patch}" >/dev/null 2>&1; then
+    fail "schema accepted an invalid spread rule (${desc})"
+  fi
+  pass "schema rejected: ${desc}"
+}
+
+schema_reject "minDomains without DoNotSchedule" '{"spec":{"primary":{"placement":{"spread":[
+  {"topologyKey":"topology.kubernetes.io/zone","minDomains":3,"whenUnsatisfiable":"ScheduleAnyway"}]}}}}'
+schema_reject "malformed topologyKey" '{"spec":{"primary":{"placement":{"spread":[
+  {"topologyKey":"not a valid key!"}]}}}}'
+schema_reject "maxSkew of 0" '{"spec":{"primary":{"placement":{"spread":[
+  {"topologyKey":"topology.kubernetes.io/zone","maxSkew":0}]}}}}'
+
+# maxItems: 8.
+NINE_RULES=$(for i in $(seq 1 9); do printf '{"topologyKey":"k%s.example.com/zone"},' "${i}"; done | sed 's/,$//')
+schema_reject "9 spread rules (max is 8)" \
+  "{\"spec\":{\"primary\":{\"placement\":{\"spread\":[${NINE_RULES}]}}}}"
+
+# 253-character prefix cap, enforced by CEL because RE2 has no lookahead.
+A63=$(repeat a 63)
+LONG_PREFIX="${A63}.${A63}.${A63}.$(repeat a 62)"     # 254 chars
+schema_reject "topologyKey prefix over 253 characters" \
+  "{\"spec\":{\"primary\":{\"placement\":{\"spread\":[{\"topologyKey\":\"${LONG_PREFIX}/zone\"}]}}}}"
+
+# ...and the maximal VALID key (253 + '/' + 63 = 317) must still be accepted,
+# so the caps are not merely tight.
+MAX_PREFIX="${A63}.${A63}.${A63}.$(repeat a 61)"      # 253 chars
+MAX_NAME=$(repeat b 63)
+${KUBECTL} patch bind9cluster "${DNS_CLUSTER}" -n "${NAMESPACE}" --type=merge \
+  -p "{\"spec\":{\"primary\":{\"placement\":{\"spread\":[{\"topologyKey\":\"${MAX_PREFIX}/${MAX_NAME}\"}]}}}}" \
+  >/dev/null 2>&1 \
+  || fail "schema rejected a maximally-sized but VALID 317-character topologyKey"
+pass "schema accepted the maximal valid topologyKey (317 chars)"
+
+echo
+echo -e "${GREEN}All zone-spreading checks passed.${NC}"


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

## Spread primary DNS pods across availability zones

Closes #467.

### Why

The Deployments built by `build_deployment` set no scheduling constraints at all, so on a multi-zone cluster every primary can land in one zone and a single zone outage takes out all authoritative DNS.

The obvious fix — one `topologySpreadConstraint` on the pod template — does nothing here. A zone's `NS` records name individual servers, so Bindy gives each nameserver its own `Bind9Instance`, Deployment and Service, and `create_managed_instance_with_owner` hardcodes `replicas: 1`. `primary.replicas: 3` is therefore **three single-pod Deployments**, and a constraint selecting its own Deployment's pods balances a set of one: always satisfied, spreads nothing.

The selector has to span the sibling Deployments. That is what this PR adds.

### Changes

- **`src/crd.rs`** — new `spec.placement.spread`, a list of typed rules (`topologyKey`, `maxSkew`, `whenUnsatisfiable`, `minDomains`, `scope`, node policies), settable on `Bind9Instance.spec` and on `spec.primary` / `spec.secondary`. Topology spreading only: no `nodeSelector` / `tolerations` / `affinity` passthrough — those added ~450KB of CRD schema and would have let a namespace tenant schedule an operator-credentialed pod onto a control-plane node. Limits are structural (`maxItems: 8`, `topologyKey` pattern, ranges, enums, and `x-kubernetes-validations` CEL for the `minDomains` pairing and the 253-char prefix cap), so the API server rejects bad input at admission with no admission policy required.
- **`src/placement.rs`** (new) — resolves `placement` (instance → role, whole-block) and builds the constraints. `scope` picks the generated `labelSelector`: `Role` (default for cluster-managed) selects on `bindy.firestoned.io/cluster` + `role`, so all primaries of a cluster balance against each other; `Instance` (default for a standalone multi-replica instance) selects the Deployment's own pods.
- **`src/bind9_resources.rs`** — split `build_labels_from_instance` (frozen; owns the immutable `spec.selector`) from `build_pod_labels_from_instance` (superset, pod template only). The cluster label had to reach pods without widening the selector, which Kubernetes rejects as immutable.
- **`src/reconcilers/bind9instance/resources.rs`** — `deployment_needs_update` and the strategic-merge patch were an allow-list of replicas + the bindcar container, so a new pod-spec field would have been written once and never reconciled. Both extended; `topologySpreadConstraints` needs `{"$patch": "replace"}` because its `patchStrategy=merge` otherwise leaves stale constraints behind on removal.
- **`src/reconcilers/bind9instance/mod.rs`** — the reconcile short-circuit compared Deployment *metadata* labels only, so Deployments predating this feature matched it and were skipped forever. Now compares pod template labels too; stale Deployments self-heal in <3s.
- **`src/main.rs`** — the instance controller watches `Bind9Cluster` / `ClusterBind9Provider`. Role-level config is resolved against the live cluster rather than copied into instance specs, so without this a change waited on the 5-minute requeue (measured ~240s → sub-second).
- **Docs** — `docs/adr/0003-pod-placement-and-zone-spreading.md`, a user guide, `examples/zone-spreading.yaml`, and `deploy/kind-config-multizone.yaml` + `tests/zone_spread_test.sh`.
- **CRD install** — `Makefile`, `crdgen` and the install docs now say `kubectl apply --server-side`, and stale `deploy/crds` paths point at `deploy/operator/crds/`. Client-side apply was already failing on `main` (`bind9clusters` is 275KB, over the 256KB `last-applied-configuration` cap); this PR adds ~51KB.

Default behaviour with no config: one soft (`ScheduleAnyway`) `maxSkew: 1` zone rule once a cluster has two or more **primaries**. Soft, because a hard default turns a single-zone cluster — or the outage this guards against — into `Pending` DNS pods. Primaries only, because defaulting secondaries would silently move already-running pods on upgrade; they opt in via `secondary.placement.spread`.

### Verification

`cargo fmt` / `clippy -D warnings --all-targets --all-features` / 1285 lib tests green.

`tests/zone_spread_test.sh` runs against a three-zone kind cluster, 9/9. The load-bearing check is not "pods landed in different zones" — the scheduler often does that anyway — but that with two of three zones cordoned the extra primaries go `Pending`:

```console
$ kubectl get pods -l bindy.firestoned.io/role=primary
zonespread-primary-0-...   Running   bindy-multizone-worker
zonespread-primary-1-...   Pending   <none>
zonespread-primary-2-...   Pending   <none>

$ kubectl get events --field-selector reason=FailedScheduling
0/4 nodes are available: 1 node(s) didn't match pod topology spread constraints, ...
```

That can only happen if the selector spans siblings; with a per-instance selector every pod schedules happily. The script also covers selector immutability, convergence of changes and removals onto existing Deployments, in-place upgrade of pre-feature Deployments, the primaries-only default, and server-side rejection of invalid rules.
