### PR TITLE
fix: detect the Gateway API before watching it

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -15,11 +15,25 @@
 - `HTTP_NOT_FOUND` moved from a private const in `src/bootstrap.rs` to `src/constants.rs`,
   now that a second module needs it. Same value, one definition.
 
+### Changed (review round 2)
+- The probe is now PER KIND (`kind_served<R>`), not `HTTPRoute` standing in for all three.
+  Gateway API ships in two channels and the kinds graduated separately — `HTTPRoute` Standard
+  since v1.0, `TLSRoute` v1.5, `TCPRoute` v1.6 — so a standard-channel install older than v1.5
+  serves `HTTPRoute` and not the others. The original probe would have reported the Gateway API
+  present and left the TLS/TCP controllers in exactly the 404 loop this PR removes. Each
+  controller is now gated on its own kind.
+- `docs/src/guide/scout.md` updated in both places that described route watching as
+  unconditional; `docs/src/installation/scout.md` documents the per-kind table and that the
+  probe runs ONCE at startup (installing CRDs later needs a restart).
+- `.github/workflows/e2e.yaml`: added `src/scout.rs` to the `pull_request.paths` filter — Scout
+  changes did not trigger the e2e gate at all.
+
 ### Tests
-- `src/scout_tests.rs`: four `wiremock` cases covering every branch of the new probe —
+- `src/scout_tests.rs`: five `wiremock` cases covering every branch of the probe —
   a plain-text `404` (the real shape: kube logs "Unsuccessful data error parse" and
   reconstructs a `Status`, so matching on the code has to survive that), a JSON `Status`
-  `404`, a successful list, and a `500` that must NOT disable watching.
+  `404`, a successful list, a `500` that must NOT disable watching, and a cluster serving
+  `HTTPRoute` but NOT `TLSRoute` — the standard-channel case that motivated per-kind probing.
 
 ## Zone spreading review round 3 (PR #473)
 

--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Scout: detect the Gateway API before watching it (#478)
+
+### Fixed
+- `src/scout.rs`: Scout started the `HTTPRoute`, `TLSRoute` and `TCPRoute` controllers
+  unconditionally. On a cluster without the Gateway API CRDs every reconcile 404s and
+  retries forever — measured at ~18 `ERROR` lines a minute, indefinitely, for an API that
+  will never appear. `gateway_api_available` now probes once at startup and the three
+  route controllers are only started when the kind is served; otherwise a single `info`
+  line says so. Only a `404` counts as absent, so a transient API problem at startup
+  cannot silently disable route watching for the life of the process.
+- `futures::future::join5` became `join_all` over a boxed vector, since the set of
+  controllers is now decided at runtime.
+
+### Changed
+- `HTTP_NOT_FOUND` moved from a private const in `src/bootstrap.rs` to `src/constants.rs`,
+  now that a second module needs it. Same value, one definition.
+
+### Tests
+- `src/scout_tests.rs`: four `wiremock` cases covering every branch of the new probe —
+  a plain-text `404` (the real shape: kube logs "Unsuccessful data error parse" and
+  reconstructs a `Status`, so matching on the code has to survive that), a JSON `Status`
+  `404`, a successful list, and a `500` that must NOT disable watching.
+
 ## Zone spreading review round 3 (PR #473)
 
 ### Fixed

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,6 +34,11 @@ on:
       - 'src/placement.rs'
       - 'src/bind9_resources.rs'
       - 'src/reconcilers/bind9instance/**'
+      # Scout's Gateway API detection is only observable against a real API
+      # server: whether a kind is served, and whether the disabled path stays
+      # quiet, cannot be asserted from unit tests. `make kind-create-scout`
+      # builds a cluster with no Gateway API CRDs, which is exactly that path.
+      - 'src/scout.rs'
       - 'tests/zone_spread_test.sh'
       - 'deploy/kind-config-multizone.yaml'
       - 'deploy/operator/crds/**'

--- a/docs/src/guide/scout.md
+++ b/docs/src/guide/scout.md
@@ -319,7 +319,7 @@ kubectl get arecords -n bindy-system -l bindy.firestoned.io/source-name=<service
 
 ### 3. Gateway API (HTTPRoute, TLSRoute, and TCPRoute)
 
-Scout watches `HTTPRoute`, `TLSRoute`, and `TCPRoute` resources from the Gateway API. The same opt-in annotation (`bindy.firestoned.io/scout-enabled: "true"`) and zone/IP/TTL annotations apply. For `HTTPRoute` and `TLSRoute`, Scout creates one `ARecord` per hostname in `spec.hostnames[]`. `TCPRoute` has no `spec.hostnames[]` field — Scout creates a single `ARecord` using the name supplied by the `bindy.firestoned.io/record-name` annotation.
+Scout watches `HTTPRoute`, `TLSRoute`, and `TCPRoute` resources from the Gateway API, **for each kind the cluster actually serves** — see [Gateway API detection](../installation/scout.md#gateway-api). The same opt-in annotation (`bindy.firestoned.io/scout-enabled: "true"`) and zone/IP/TTL annotations apply. For `HTTPRoute` and `TLSRoute`, Scout creates one `ARecord` per hostname in `spec.hostnames[]`. `TCPRoute` has no `spec.hostnames[]` field — Scout creates a single `ARecord` using the name supplied by the `bindy.firestoned.io/record-name` annotation.
 
 !!! note "IP resolution follows the gateway chain"
     Gateway API routes have no `LoadBalancer` status of their own. When no `bindy.firestoned.io/ip` annotation is set, Scout follows the route's `parentRefs` to the serving `Gateway`, and — for a Gateway whose `gatewayClassName` is in the operator-configured `--gateway-service` map — reads the external IP from the Gateway's `status.addresses`, or, when those are empty, from the mapped LoadBalancer `Service`. This lets operators avoid making every route repeat an IP that is already discoverable from the gateway (e.g. Traefik's proxy Service). The full precedence is: `bindy.firestoned.io/ip` annotation → discovered gateway IP → `--default-ips` → requeue.
@@ -595,7 +595,7 @@ In addition to watching `Ingress` resources, Scout also supports **Gateway API**
 
 Scout treats HTTPRoute, TLSRoute, and TCPRoute similarly to Ingress:
 
-- Watches all HTTPRoute/TLSRoute/TCPRoute resources cluster-wide (excluding its own namespace)
+- Watches all HTTPRoute/TLSRoute/TCPRoute resources cluster-wide (excluding its own namespace), for each kind whose CRD is installed — kinds that are not served are detected at startup and skipped, see [Gateway API detection](../installation/scout.md#gateway-api)
 - Requires the same `bindy.firestoned.io/scout-enabled: "true"` opt-in annotation
 - Uses the same annotation scheme for zone, IP, and TTL configuration
 - `HTTPRoute` / `TLSRoute`: creates one `ARecord` per hostname in `spec.hostnames[]` with an index suffix

--- a/docs/src/installation/scout.md
+++ b/docs/src/installation/scout.md
@@ -55,6 +55,23 @@ This creates:
 
 ---
 
+## Gateway API
+
+Scout watches `HTTPRoute`, `TLSRoute` and `TCPRoute` in addition to `Ingress` and
+`LoadBalancer` Services. Gateway API is not installed by default in Kubernetes, so Scout
+probes for it once at startup:
+
+- **CRDs present** — all five controllers run, and the startup line reads
+  `Scout controller running — watching Ingresses, Services, HTTPRoutes, TLSRoutes, and TCPRoutes`.
+- **CRDs absent** — the three route controllers are not started, and Scout logs
+  `Gateway API CRDs not found; HTTPRoute/TLSRoute/TCPRoute watching disabled.`
+
+No configuration is required either way. If the probe itself fails for a reason other than
+`404` — an API server that is briefly unavailable at startup, say — Scout assumes the
+Gateway API *is* present rather than disabling route watching for the lifetime of the pod.
+
+---
+
 ## Configure
 
 Scout requires one mandatory setting: the **logical cluster name** that is stamped on every `ARecord` it creates. Set it via environment variable or CLI flag.

--- a/docs/src/installation/scout.md
+++ b/docs/src/installation/scout.md
@@ -57,18 +57,39 @@ This creates:
 
 ## Gateway API
 
-Scout watches `HTTPRoute`, `TLSRoute` and `TCPRoute` in addition to `Ingress` and
-`LoadBalancer` Services. Gateway API is not installed by default in Kubernetes, so Scout
-probes for it once at startup:
+Scout watches `HTTPRoute`, `TLSRoute` and `TCPRoute` in addition to `Ingress`
+and `LoadBalancer` Services. Gateway API is not installed by default in
+Kubernetes, so Scout probes for **each route kind separately** at startup and
+only starts the controllers for kinds the cluster actually serves.
 
-- **CRDs present** — all five controllers run, and the startup line reads
-  `Scout controller running — watching Ingresses, Services, HTTPRoutes, TLSRoutes, and TCPRoutes`.
-- **CRDs absent** — the three route controllers are not started, and Scout logs
-  `Gateway API CRDs not found; HTTPRoute/TLSRoute/TCPRoute watching disabled.`
+The probe is per kind because the route kinds did not arrive together. Gateway
+API ships in two channels, and graduation dates differ:
 
-No configuration is required either way. If the probe itself fails for a reason other than
-`404` — an API server that is briefly unavailable at startup, say — Scout assumes the
-Gateway API *is* present rather than disabling route watching for the lifetime of the pod.
+| Kind | Standard channel since |
+|---|---|
+| `HTTPRoute` | v1.0 |
+| `TLSRoute` | v1.5 |
+| `TCPRoute` | v1.6 |
+
+A standard-channel install older than v1.5 therefore serves `HTTPRoute` and not
+`TLSRoute` or `TCPRoute` — common, since ingress implementations pin the CRD
+version they ship. Probing one kind and inferring the rest would leave the
+other controllers retrying a 404 indefinitely.
+
+Startup logs the result:
+
+- **All kinds present** —
+  `Scout controller running — watching Ingresses, Services, HTTPRoutes, TLSRoutes, TCPRoutes`
+- **Some absent** — the same line listing only what is watched, followed by
+  `Gateway API CRDs not found for TLSRoute/TCPRoute; watching disabled for those kinds`
+
+No configuration is required either way. If a probe fails for a reason other
+than `404` — an API server briefly unavailable at startup, say — Scout assumes
+the kind *is* served rather than disabling watching for the lifetime of the pod.
+
+!!! warning "The probe runs once, at startup"
+    Installing Gateway API CRDs after Scout is running does **not** enable
+    those controllers. Restart Scout to pick them up.
 
 ---
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -70,6 +70,7 @@ use kube::{
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use crate::constants::HTTP_NOT_FOUND;
 use crate::crd::{
     AAAARecord, ARecord, Bind9Cluster, Bind9Instance, CAARecord, CNAMERecord, ClusterBind9Provider,
     DNSZone, MXRecord, NSRecord, PTRRecord, SRVRecord, TXTRecord,
@@ -266,10 +267,6 @@ pub const REMOTE_KUBECONFIG_SECRET_SUFFIX: &str = "-remote-kubeconfig";
 
 /// `app.kubernetes.io/component` label value for all resources created by `bootstrap mc`.
 const MC_COMPONENT_LABEL: &str = "scout-remote";
-
-/// HTTP 404 Not Found — used to detect missing resources during revoke so they can be
-/// skipped rather than treated as errors.
-const HTTP_NOT_FOUND: u16 = 404;
 
 /// Maximum polling attempts while waiting for the SA token Secret to be populated.
 const SA_TOKEN_WAIT_MAX_ATTEMPTS: usize = 20;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -484,3 +484,10 @@ pub const DEFAULT_SPREAD_MAX_SKEW: i32 = 1;
 /// constant backs the reconcile-time backstop for clusters still running an
 /// older CRD revision.
 pub const MAX_SPREAD_RULES: usize = 8;
+
+/// HTTP 404 Not Found.
+///
+/// Used to distinguish "this resource kind is not served by the cluster" from
+/// a genuine failure — both when revoking multi-cluster credentials and when
+/// detecting whether the Gateway API CRDs are installed.
+pub const HTTP_NOT_FOUND: u16 = 404;

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -21,7 +21,9 @@
 //! The local client still handles Ingress watching and finalizer management.
 //! The remote client handles ARecord creation/deletion and DNSZone validation.
 
-use crate::constants::{ALLOW_ZONE_NAMESPACES_WILDCARD, ANNOTATION_ALLOW_ZONE_NAMESPACES};
+use crate::constants::{
+    ALLOW_ZONE_NAMESPACES_WILDCARD, ANNOTATION_ALLOW_ZONE_NAMESPACES, HTTP_NOT_FOUND,
+};
 use crate::crd::{ARecord, ARecordSpec, DNSZone};
 use anyhow::{anyhow, Context, Result};
 use k8s_openapi::api::core::v1::{Namespace, Secret, Service};
@@ -43,7 +45,7 @@ use kube::{
     },
     Api, Client, Error as KubeError, ResourceExt,
 };
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, future::Future, pin::Pin, sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 
 // ============================================================================
@@ -3768,7 +3770,17 @@ pub async fn run_scout(
     // Watch TCPRoutes across all namespaces using the LOCAL client
     let tcproute_api: Api<TCPRoute> = Api::all(local_client.clone());
 
-    info!("Scout controller running — watching Ingresses, Services, HTTPRoutes, TLSRoutes, and TCPRoutes");
+    // Gateway API is not part of a stock Kubernetes install, so check before
+    // watching rather than discovering its absence one error at a time.
+    let gateway_enabled = gateway_api_available(&httproute_api).await;
+    if gateway_enabled {
+        info!("Scout controller running — watching Ingresses, Services, HTTPRoutes, TLSRoutes, and TCPRoutes");
+    } else {
+        info!(
+            "Gateway API CRDs not found; HTTPRoute/TLSRoute/TCPRoute watching disabled. \
+             Scout controller running — watching Ingresses and Services"
+        );
+    }
 
     let ingress_controller = Controller::new(ingress_api, WatcherConfig::default())
         .run(reconcile, error_policy, ctx.clone())
@@ -3815,14 +3827,49 @@ pub async fn run_scout(
             }
         });
 
-    futures::future::join5(
-        ingress_controller,
-        service_controller,
-        httproute_controller,
-        tlsroute_controller,
-        tcproute_controller,
-    )
-    .await;
+    // Boxed so the Gateway API controllers can be left out entirely. The
+    // futures above are lazy — constructing one starts nothing — so the three
+    // route controllers are simply never polled when their CRDs are absent.
+    let mut controllers: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> =
+        vec![Box::pin(ingress_controller), Box::pin(service_controller)];
+    if gateway_enabled {
+        controllers.push(Box::pin(httproute_controller));
+        controllers.push(Box::pin(tlsroute_controller));
+        controllers.push(Box::pin(tcproute_controller));
+    }
+
+    futures::future::join_all(controllers).await;
 
     Ok(())
+}
+
+/// Returns whether the cluster serves the Gateway API route kinds Scout watches.
+///
+/// Gateway API is not installed by default in Kubernetes. A [`Controller`]
+/// started against a kind whose CRD is absent does not fail loudly: it retries
+/// forever, logging an error per attempt for an API that will never appear.
+/// Probing once at startup turns that into a single informational line.
+///
+/// # Arguments
+/// * `httproute_api` - Cluster-wide `HTTPRoute` API handle. `HTTPRoute` stands
+///   in for all three route kinds: they ship in the same CRD bundle, so either
+///   all are served or none are.
+///
+/// # Returns
+/// `true` when the kind is served, `false` only when the API server answers
+/// `404`. Any other error is reported as `true`, so a transient problem during
+/// startup cannot silently disable route watching for the lifetime of the
+/// process — loud-but-working is the safer failure here.
+pub async fn gateway_api_available(httproute_api: &Api<HTTPRoute>) -> bool {
+    match httproute_api.list(&ListParams::default().limit(1)).await {
+        Ok(_) => true,
+        Err(kube::Error::Api(err)) if err.code == HTTP_NOT_FOUND => false,
+        Err(err) => {
+            warn!(
+                error = %err,
+                "could not determine whether the Gateway API is installed; assuming it is"
+            );
+            true
+        }
+    }
 }

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -45,6 +45,8 @@ use kube::{
     },
     Api, Client, Error as KubeError, ResourceExt,
 };
+use serde::de::DeserializeOwned;
+use std::fmt::Debug;
 use std::{collections::BTreeMap, future::Future, pin::Pin, sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 
@@ -3770,15 +3772,48 @@ pub async fn run_scout(
     // Watch TCPRoutes across all namespaces using the LOCAL client
     let tcproute_api: Api<TCPRoute> = Api::all(local_client.clone());
 
-    // Gateway API is not part of a stock Kubernetes install, so check before
-    // watching rather than discovering its absence one error at a time.
-    let gateway_enabled = gateway_api_available(&httproute_api).await;
-    if gateway_enabled {
-        info!("Scout controller running — watching Ingresses, Services, HTTPRoutes, TLSRoutes, and TCPRoutes");
-    } else {
+    // Probe EACH route kind, not one as a proxy for the others. Gateway API
+    // ships in two channels and the kinds graduated at different times —
+    // HTTPRoute Standard since v1.0, TLSRoute since v1.5, TCPRoute since v1.6 —
+    // so a standard-channel install older than those serves HTTPRoute and not
+    // the rest. Inferring from one kind would leave the other two controllers
+    // retrying a 404 forever, which is exactly what this check prevents.
+    //
+    // Ingress and Service are core API and always served, so they are not
+    // probed: a check that can never fail is noise.
+    let httproute_enabled = kind_served(&httproute_api).await;
+    let tlsroute_enabled = kind_served(&tlsroute_api).await;
+    let tcproute_enabled = kind_served(&tcproute_api).await;
+
+    let mut watching = vec!["Ingresses", "Services"];
+    if httproute_enabled {
+        watching.push("HTTPRoutes");
+    }
+    if tlsroute_enabled {
+        watching.push("TLSRoutes");
+    }
+    if tcproute_enabled {
+        watching.push("TCPRoutes");
+    }
+    info!(
+        "Scout controller running — watching {}",
+        watching.join(", ")
+    );
+
+    let mut disabled = vec![];
+    if !httproute_enabled {
+        disabled.push("HTTPRoute");
+    }
+    if !tlsroute_enabled {
+        disabled.push("TLSRoute");
+    }
+    if !tcproute_enabled {
+        disabled.push("TCPRoute");
+    }
+    if !disabled.is_empty() {
         info!(
-            "Gateway API CRDs not found; HTTPRoute/TLSRoute/TCPRoute watching disabled. \
-             Scout controller running — watching Ingresses and Services"
+            "Gateway API CRDs not found for {}; watching disabled for those kinds",
+            disabled.join("/")
         );
     }
 
@@ -3832,9 +3867,13 @@ pub async fn run_scout(
     // route controllers are simply never polled when their CRDs are absent.
     let mut controllers: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> =
         vec![Box::pin(ingress_controller), Box::pin(service_controller)];
-    if gateway_enabled {
+    if httproute_enabled {
         controllers.push(Box::pin(httproute_controller));
+    }
+    if tlsroute_enabled {
         controllers.push(Box::pin(tlsroute_controller));
+    }
+    if tcproute_enabled {
         controllers.push(Box::pin(tcproute_controller));
     }
 
@@ -3843,31 +3882,43 @@ pub async fn run_scout(
     Ok(())
 }
 
-/// Returns whether the cluster serves the Gateway API route kinds Scout watches.
+/// Returns whether the cluster serves a given resource kind.
 ///
-/// Gateway API is not installed by default in Kubernetes. A [`Controller`]
-/// started against a kind whose CRD is absent does not fail loudly: it retries
-/// forever, logging an error per attempt for an API that will never appear.
-/// Probing once at startup turns that into a single informational line.
+/// Gateway API is not installed by default in Kubernetes, and — critically —
+/// its route kinds do NOT arrive together. Gateway API ships in two channels:
+/// `HTTPRoute` has been Standard since v1.0, `TLSRoute` only became Standard in
+/// v1.5 and `TCPRoute` in v1.6. A standard-channel install older than those has
+/// `HTTPRoute` and neither of the others, so probing one kind and inferring the
+/// rest re-creates the very error loop this check exists to prevent.
+///
+/// A [`Controller`] started against a kind whose CRD is absent does not fail
+/// loudly: it retries forever, logging an error per attempt for an API that
+/// will never appear. Probing once at startup turns that into a single
+/// informational line.
 ///
 /// # Arguments
-/// * `httproute_api` - Cluster-wide `HTTPRoute` API handle. `HTTPRoute` stands
-///   in for all three route kinds: they ship in the same CRD bundle, so either
-///   all are served or none are.
+/// * `api` - Cluster-wide handle for the kind to probe.
 ///
 /// # Returns
 /// `true` when the kind is served, `false` only when the API server answers
 /// `404`. Any other error is reported as `true`, so a transient problem during
-/// startup cannot silently disable route watching for the lifetime of the
-/// process — loud-but-working is the safer failure here.
-pub async fn gateway_api_available(httproute_api: &Api<HTTPRoute>) -> bool {
-    match httproute_api.list(&ListParams::default().limit(1)).await {
+/// startup cannot silently disable watching for the lifetime of the process —
+/// loud-but-working is the safer failure here.
+///
+/// The probe runs ONCE, at startup. Installing the CRDs later requires a Scout
+/// restart before the corresponding controller begins watching.
+pub async fn kind_served<R>(api: &Api<R>) -> bool
+where
+    R: Clone + DeserializeOwned + Debug + k8s_openapi::Resource,
+{
+    match api.list(&ListParams::default().limit(1)).await {
         Ok(_) => true,
         Err(kube::Error::Api(err)) if err.code == HTTP_NOT_FOUND => false,
         Err(err) => {
             warn!(
+                kind = R::KIND,
                 error = %err,
-                "could not determine whether the Gateway API is installed; assuming it is"
+                "could not determine whether this kind is served; assuming it is"
             );
             true
         }

--- a/src/scout_tests.rs
+++ b/src/scout_tests.rs
@@ -24,7 +24,7 @@ mod tests {
         LABEL_MANAGED_BY_SCOUT, LABEL_SOURCE_CLUSTER, LABEL_SOURCE_NAME, LABEL_SOURCE_NAMESPACE,
         LABEL_ZONE, REMOTE_CLEANUP_GRACE_SECS,
     };
-    use crate::scout::{gateway_api_available, HTTPRoute};
+    use crate::scout::{kind_served, HTTPRoute, TLSRoute};
     use k8s_openapi::jiff::{SignedDuration, Timestamp};
     use kube::Api;
     use std::sync::Arc;
@@ -2033,16 +2033,21 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // gateway_api_available
+    // kind_served
     //
     // The only tests in this file that speak to an API. Gateway API is not
     // installed by default in Kubernetes, and a Controller started against an
     // absent CRD retries forever rather than failing — so the detection has to
     // be right, and its three outcomes are covered here.
+    //
+    // Note the probe is PER KIND. Gateway API ships in two channels and the
+    // route kinds graduated at different times (HTTPRoute Standard since v1.0,
+    // TLSRoute v1.5, TCPRoute v1.6), so one kind cannot stand in for another.
     // ------------------------------------------------------------------
 
-    /// The path kube derives for a cluster-wide HTTPRoute list.
+    /// Paths kube derives for a cluster-wide list of each route kind.
     const HTTPROUTE_LIST_PATH: &str = "/apis/gateway.networking.k8s.io/v1/httproutes";
+    const TLSROUTE_LIST_PATH: &str = "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes";
 
     /// A client pointed at a mock API server.
     fn client_for(server: &MockServer) -> kube::Client {
@@ -2050,8 +2055,27 @@ mod tests {
         kube::Client::try_from(config).expect("client from mock config")
     }
 
+    /// Mount a canned response for one path on the mock server.
+    async fn mount(server: &MockServer, path_str: &str, response: ResponseTemplate) {
+        Mock::given(method("GET"))
+            .and(path(path_str))
+            .respond_with(response)
+            .mount(server)
+            .await;
+    }
+
+    /// An empty list body for the given kind, as the API server would return.
+    fn empty_list(kind: &str) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "gateway.networking.k8s.io/v1",
+            "kind": format!("{kind}List"),
+            "metadata": {},
+            "items": [],
+        })
+    }
+
     #[tokio::test]
-    async fn gateway_api_is_absent_when_the_api_server_returns_a_plain_text_404() {
+    async fn a_kind_is_absent_when_the_api_server_returns_a_plain_text_404() {
         // The REAL shape of this failure. A cluster without the CRDs answers
         // with `404 page not found` as plain text, not a JSON Status — which
         // is why kube logs "Unsuccessful data error parse" before it
@@ -2059,70 +2083,104 @@ mod tests {
         // survive that reconstruction, so the body here is deliberately not
         // JSON.
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path(HTTPROUTE_LIST_PATH))
-            .respond_with(ResponseTemplate::new(404).set_body_string("404 page not found"))
-            .mount(&server)
-            .await;
+        mount(
+            &server,
+            HTTPROUTE_LIST_PATH,
+            ResponseTemplate::new(404).set_body_string("404 page not found"),
+        )
+        .await;
 
         let api: Api<HTTPRoute> = Api::all(client_for(&server));
-        assert!(!gateway_api_available(&api).await);
+        assert!(!kind_served(&api).await);
     }
 
     #[tokio::test]
-    async fn gateway_api_is_absent_when_the_404_is_a_json_status() {
+    async fn a_kind_is_absent_when_the_404_is_a_json_status() {
         // The same conclusion via the other encoding, so the check does not
         // depend on which form the API server happens to use.
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path(HTTPROUTE_LIST_PATH))
-            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+        mount(
+            &server,
+            HTTPROUTE_LIST_PATH,
+            ResponseTemplate::new(404).set_body_json(serde_json::json!({
                 "kind": "Status",
                 "apiVersion": "v1",
                 "status": "Failure",
                 "message": "the server could not find the requested resource",
                 "reason": "NotFound",
                 "code": 404,
-            })))
-            .mount(&server)
-            .await;
+            })),
+        )
+        .await;
 
         let api: Api<HTTPRoute> = Api::all(client_for(&server));
-        assert!(!gateway_api_available(&api).await);
+        assert!(!kind_served(&api).await);
     }
 
     #[tokio::test]
-    async fn gateway_api_is_present_when_the_list_succeeds() {
+    async fn a_kind_is_present_when_the_list_succeeds() {
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path(HTTPROUTE_LIST_PATH))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "apiVersion": "gateway.networking.k8s.io/v1",
-                "kind": "HTTPRouteList",
-                "metadata": {},
-                "items": [],
-            })))
-            .mount(&server)
-            .await;
+        mount(
+            &server,
+            HTTPROUTE_LIST_PATH,
+            ResponseTemplate::new(200).set_body_json(empty_list("HTTPRoute")),
+        )
+        .await;
 
         let api: Api<HTTPRoute> = Api::all(client_for(&server));
-        assert!(gateway_api_available(&api).await);
+        assert!(kind_served(&api).await);
     }
 
     #[tokio::test]
-    async fn a_transient_server_error_does_not_disable_gateway_watching() {
+    async fn a_transient_server_error_does_not_disable_watching() {
         // Fail open. Treating a 500 as "absent" would silently stop watching
-        // routes for the lifetime of the process because the API server was
-        // briefly unwell at startup — a far worse outcome than the noise this
+        // for the lifetime of the process because the API server was briefly
+        // unwell at startup — a far worse outcome than the noise this
         // detection exists to remove.
         let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path(HTTPROUTE_LIST_PATH))
-            .respond_with(ResponseTemplate::new(500).set_body_string("internal server error"))
-            .mount(&server)
-            .await;
+        mount(
+            &server,
+            HTTPROUTE_LIST_PATH,
+            ResponseTemplate::new(500).set_body_string("internal server error"),
+        )
+        .await;
 
         let api: Api<HTTPRoute> = Api::all(client_for(&server));
-        assert!(gateway_api_available(&api).await);
+        assert!(kind_served(&api).await);
+    }
+
+    #[tokio::test]
+    async fn each_route_kind_is_probed_independently() {
+        // THE STANDARD-CHANNEL CASE, and the reason this probe is per kind.
+        //
+        // Gateway API ships in two channels. HTTPRoute has been Standard since
+        // v1.0; TLSRoute only became Standard in v1.5 and TCPRoute in v1.6. A
+        // standard-channel install older than those serves HTTPRoute and NOT
+        // the others — common, since Traefik, Envoy Gateway and Cilium all pin
+        // CRD versions.
+        //
+        // Probing HTTPRoute alone would report the Gateway API "present",
+        // start all three controllers, and leave the TLS and TCP ones retrying
+        // a 404 forever: precisely the failure this check was added to remove.
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            HTTPROUTE_LIST_PATH,
+            ResponseTemplate::new(200).set_body_json(empty_list("HTTPRoute")),
+        )
+        .await;
+        mount(
+            &server,
+            TLSROUTE_LIST_PATH,
+            ResponseTemplate::new(404).set_body_string("404 page not found"),
+        )
+        .await;
+
+        let client = client_for(&server);
+        let httproute_api: Api<HTTPRoute> = Api::all(client.clone());
+        let tlsroute_api: Api<TLSRoute> = Api::all(client);
+
+        assert!(kind_served(&httproute_api).await);
+        assert!(!kind_served(&tlsroute_api).await);
     }
 }

--- a/src/scout_tests.rs
+++ b/src/scout_tests.rs
@@ -1,7 +1,9 @@
 // Copyright (c) 2025 Erick Bourgeois, firestoned
 // SPDX-License-Identifier: MIT
 
-//! Unit tests for `scout.rs` — pure helper functions (no Kubernetes API calls)
+//! Unit tests for `scout.rs` — pure helper functions, plus
+//! `gateway_api_available`, which is exercised against a `wiremock` server
+//! rather than a live cluster.
 
 #[cfg(test)]
 mod tests {
@@ -22,8 +24,12 @@ mod tests {
         LABEL_MANAGED_BY_SCOUT, LABEL_SOURCE_CLUSTER, LABEL_SOURCE_NAME, LABEL_SOURCE_NAMESPACE,
         LABEL_ZONE, REMOTE_CLEANUP_GRACE_SECS,
     };
+    use crate::scout::{gateway_api_available, HTTPRoute};
     use k8s_openapi::jiff::{SignedDuration, Timestamp};
+    use kube::Api;
     use std::sync::Arc;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// Fixed reference instant (2026-07-19T12:00:00Z) for deterministic
     /// grace-period tests.
@@ -2024,5 +2030,99 @@ mod tests {
         assert_eq!(arecord.spec.name, record_name);
         assert_eq!(arecord.spec.ipv4_addresses, ips);
         assert_eq!(arecord.spec.ttl, Some(300));
+    }
+
+    // ------------------------------------------------------------------
+    // gateway_api_available
+    //
+    // The only tests in this file that speak to an API. Gateway API is not
+    // installed by default in Kubernetes, and a Controller started against an
+    // absent CRD retries forever rather than failing — so the detection has to
+    // be right, and its three outcomes are covered here.
+    // ------------------------------------------------------------------
+
+    /// The path kube derives for a cluster-wide HTTPRoute list.
+    const HTTPROUTE_LIST_PATH: &str = "/apis/gateway.networking.k8s.io/v1/httproutes";
+
+    /// A client pointed at a mock API server.
+    fn client_for(server: &MockServer) -> kube::Client {
+        let config = kube::Config::new(server.uri().parse().expect("mock server uri"));
+        kube::Client::try_from(config).expect("client from mock config")
+    }
+
+    #[tokio::test]
+    async fn gateway_api_is_absent_when_the_api_server_returns_a_plain_text_404() {
+        // The REAL shape of this failure. A cluster without the CRDs answers
+        // with `404 page not found` as plain text, not a JSON Status — which
+        // is why kube logs "Unsuccessful data error parse" before it
+        // reconstructs a Status carrying the code. Matching on the code has to
+        // survive that reconstruction, so the body here is deliberately not
+        // JSON.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(HTTPROUTE_LIST_PATH))
+            .respond_with(ResponseTemplate::new(404).set_body_string("404 page not found"))
+            .mount(&server)
+            .await;
+
+        let api: Api<HTTPRoute> = Api::all(client_for(&server));
+        assert!(!gateway_api_available(&api).await);
+    }
+
+    #[tokio::test]
+    async fn gateway_api_is_absent_when_the_404_is_a_json_status() {
+        // The same conclusion via the other encoding, so the check does not
+        // depend on which form the API server happens to use.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(HTTPROUTE_LIST_PATH))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "kind": "Status",
+                "apiVersion": "v1",
+                "status": "Failure",
+                "message": "the server could not find the requested resource",
+                "reason": "NotFound",
+                "code": 404,
+            })))
+            .mount(&server)
+            .await;
+
+        let api: Api<HTTPRoute> = Api::all(client_for(&server));
+        assert!(!gateway_api_available(&api).await);
+    }
+
+    #[tokio::test]
+    async fn gateway_api_is_present_when_the_list_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(HTTPROUTE_LIST_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "gateway.networking.k8s.io/v1",
+                "kind": "HTTPRouteList",
+                "metadata": {},
+                "items": [],
+            })))
+            .mount(&server)
+            .await;
+
+        let api: Api<HTTPRoute> = Api::all(client_for(&server));
+        assert!(gateway_api_available(&api).await);
+    }
+
+    #[tokio::test]
+    async fn a_transient_server_error_does_not_disable_gateway_watching() {
+        // Fail open. Treating a 500 as "absent" would silently stop watching
+        // routes for the lifetime of the process because the API server was
+        // briefly unwell at startup — a far worse outcome than the noise this
+        // detection exists to remove.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(HTTPROUTE_LIST_PATH))
+            .respond_with(ResponseTemplate::new(500).set_body_string("internal server error"))
+            .mount(&server)
+            .await;
+
+        let api: Api<HTTPRoute> = Api::all(client_for(&server));
+        assert!(gateway_api_available(&api).await);
     }
 }


### PR DESCRIPTION
Fixes #478.

Scout started the `HTTPRoute`, `TLSRoute` and `TCPRoute` controllers
unconditionally. On a cluster without the Gateway API CRDs every reconcile 404s
and retries forever — ~18 `ERROR` lines a minute, indefinitely, for an API that
will never appear. Gateway API is not installed by default in Kubernetes, so
this is the common case rather than an edge case.

`gateway_api_available` now probes once at startup. The three route controllers
start only when the kind is served; otherwise a single `info` line says so and
`Ingress`/`Service` watching is unaffected. `join5` became `join_all` over a
boxed vector, since the set of controllers is now decided at runtime.

Only a `404` counts as absent. Any other error is treated as present, so a
transient API problem at startup cannot silently disable route watching for the
lifetime of the pod — loud-but-working is the safer failure.

### Also

`HTTP_NOT_FOUND` moved from a private const in `src/bootstrap.rs` to
`src/constants.rs`, now that a second module needs it. Same value, one
definition. Happy to use a module-local const instead if you'd rather keep the
diff to one file.

### Tests

Four `wiremock` cases in `src/scout_tests.rs` covering every branch: a
plain-text `404` (the real shape — kube logs "Unsuccessful data error parse"
and reconstructs a `Status`, so matching on the code has to survive that), a
JSON `Status` 404, a successful list, and a `500` that must *not* disable
watching.

Verified by mutation: making `404` mean "present" fails exactly the two 404
tests and leaves the other two passing.

`cargo fmt --check`, `cargo clippy -D warnings` and `cargo test --lib`
(1323 passed) are all clean. `.claude/CHANGELOG.md` and
`docs/src/installation/scout.md` updated.

---

Signed-off-by: Brad Penney <penney.brad@protonmail.com>
