### PR TITLE
namespace-scoped watches, ConfigMap integrity policy, digest-pinned releases

### DIFF
--- a/.claude/CHANGELOG.md
+++ b/.claude/CHANGELOG.md
@@ -1,3 +1,81 @@
+## [2026-09-11 20:40] - Namespace-scoped operator (C2/H3), ConfigMap integrity, zone-authz TOCTOU, digest-pinned releases
+
+**Author:** Erick Bourgeois
+
+### Added
+- **Namespace-scoped operator mode (P1-2).** `BINDY_WATCH_NAMESPACES` is now wired
+  through the whole control plane. When set, every reflector and controller is built
+  with `Api::namespaced` per namespace and the operator needs only a Role/RoleBinding
+  in each — closing audit findings **C2** (cluster-wide `deployments create/update/
+  patch`, a privilege-escalation path via `serviceAccountName`) and **H3**
+  (cluster-wide `secrets get/list/watch`). Unset remains cluster-wide and unchanged.
+  - `src/context.rs`: new `MultiStore<K>` — one reflector `Store` shard per watched
+    namespace. **This sharding is load-bearing.** A single `Store` cannot be fed by
+    several namespace watches merged with `select_all`: `watcher::Event::InitDone`
+    makes the store *replace* its contents with the finishing watch's buffer
+    (`kube_runtime::reflector::store` does `mem::swap`), so a merged design would
+    silently leave the store holding only the last namespace to sync — and again on
+    every watch reconnect. Cluster-wide mode is a single shard with a pass-through.
+  - `src/main.rs`: `spawn_sharded_reflector` (one watcher per namespace, predicate-
+    filtered) and `spawn_cluster_reflector` for cluster-scoped kinds; per-namespace
+    controller fan-out for Bind9Cluster, Bind9Instance and DNSZone.
+  - `src/record_operator.rs`: same fan-out for all 9 record kinds.
+  - `src/namespace_scope.rs`: `scoped_namespaced_api` helper.
+  - `deploy/operator/rbac/namespaced/`: slim ClusterRole (`clusterbind9providers`
+    only), per-namespace Role, bindings, and an install README.
+- **VAP 17/18 — ConfigMap integrity (P2-2).** Operator-generated ConfigMaps
+  (`app.kubernetes.io/part-of: bindy`) may only be modified by the operator SA.
+- `Makefile`: `pin-release-images` resolves the pushed image's multi-arch digest and
+  rewrites the generated release manifests to `@sha256:` (P2-8). Fails the release if
+  the digest cannot be resolved, rather than shipping an unpinned manifest.
+
+### Changed
+- `src/scout.rs`: `check_zone_authorization_live` re-reads the granting DNSZone
+  immediately before the server-side apply (P3-4), shrinking the TOCTOU window from
+  watch latency to one API round trip. Fails **open** on a transient API error — the
+  cached grant was affirmative and failing closed would drop legitimate records
+  during an API-server blip.
+- `deploy/pod-hardening.yaml`: the bindcar API ingress rule had **no `from:`
+  selector**, so any pod in the cluster could reach it. Restricted to the operator —
+  least privilege for a management API (P2-4, partial).
+- `.github/workflows/build.yaml`: `package-deploy-manifests` now also needs
+  `docker-release`. It previously needed only `extract-version`, so it did not wait
+  for the image push — meaning a digest could not have been resolved there at all.
+- `docs/src/security/threat-model.md`: M-22 flipped to implemented (opt-in).
+
+### Why P2-2 was NOT fixed with `immutable: true`
+The roadmap's stated fix is wrong for this codebase. These ConfigMaps carry
+`named.conf` and are **mounted as volumes** by the BIND9 operand pods. The kubelet
+deliberately stops watching an immutable ConfigMap, so marking them immutable would
+mean a zone or ACL change could never reach a running pod — every DNS config update
+would become a rolling restart of the DNS servers. That trades a tampering risk for
+an availability risk. VAP 17/18 gives the same tamper-resistance at no availability
+cost. Literal immutability would require content-hashed ConfigMap names plus
+Deployment rollout; that is a feature, not a hardening tweak.
+
+### Why P2-4 is only partial
+Transport hardening for the operator-to-sidecar link depends on capability that lives
+in the bindcar project, not here. What is in scope for this repo — restricting who may
+reach the sidecar's management port — is done. The remainder is tracked privately
+until the upstream support lands, in line with how the other unremediated findings in
+this audit are handled.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
+Rollout: default behaviour is unchanged (`BINDY_WATCH_NAMESPACES` unset = cluster-wide).
+To opt in, follow `deploy/operator/rbac/namespaced/README.md` — the namespace list in
+the RBAC must match the env var exactly, or the operator crash-loops on 403s.
+`make admission-policies-install` now also applies 17/18.
+
+Verified: `cargo fmt`/`clippy` clean, 1383 lib tests; `make kind-integration-test`
+green in default mode; scoped mode verified on kind with `kubectl auth can-i`
+(cluster-wide Secret read and Deployment create both denied) and a three-namespace
+fan-out test where the two watched namespaces reconciled and the unwatched one did not.
+
 ## [2026-09-10 18:05] - Scout input validation, wildcard guardrail, and a fixed integration-test harness
 
 **Author:** Erick Bourgeois

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -824,7 +824,9 @@ jobs:
     name: Package Deployment Manifests
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    needs: extract-version
+    # docker-release is required: the manifests are digest-pinned below, and an image
+    # only HAS a digest once it has been built and pushed (audit finding P2-8).
+    needs: [extract-version, docker-release]
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -837,6 +839,12 @@ jobs:
 
       - name: Generate release manifests
         run: make release-manifests VERSION=${{ github.event.release.tag_name }}
+
+      # Pin the operator image by multi-arch digest so a published install.yaml
+      # cannot silently change under a moved tag. Fails the release rather than
+      # shipping an unpinned manifest.
+      - name: Pin release manifests by digest
+        run: make pin-release-images VERSION=${{ github.event.release.tag_name }}
 
       - name: Upload deploy manifests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Erick Bourgeois, firestoned
 # SPDX-License-Identifier: MIT
 
-.PHONY: help install test lint format docker-build docker-push deploy clean kind-create kind-deploy kind-test kind-cleanup kind-create-scout kind-scout-cleanup docs docs-serve docs-rustdoc docs-clean crds crds-combined install-yaml scout-yaml admission-policies-yaml release-manifests integ-test-multi-tenancy sign-verify-install verify-image verify-binary sign-binary cargo-deny cargo-machete gitleaks gitleaks-install vexctl-install vex-validate security-scan-local security-scan-quick security-scan-full install-git-hooks admission-policies-install admission-policies-test admission-policies-uninstall regression-test regression-test-fresh ci-e2e calm-validate calm-docs calm-docs-check
+.PHONY: pin-release-images help install test lint format docker-build docker-push deploy clean kind-create kind-deploy kind-test kind-cleanup kind-create-scout kind-scout-cleanup docs docs-serve docs-rustdoc docs-clean crds crds-combined install-yaml scout-yaml admission-policies-yaml release-manifests integ-test-multi-tenancy sign-verify-install verify-image verify-binary sign-binary cargo-deny cargo-machete gitleaks gitleaks-install vexctl-install vex-validate security-scan-local security-scan-quick security-scan-full install-git-hooks admission-policies-install admission-policies-test admission-policies-uninstall regression-test regression-test-fresh ci-e2e calm-validate calm-docs calm-docs-check
 
 # Detect host architecture and derive the matching Linux cross-compilation target.
 # `uname -m` reports arm64 on Apple Silicon macOS but aarch64 on Linux ARM, so
@@ -187,6 +187,12 @@ admission-policies-yaml: ## Generate combined admission-policies.yaml (all Valid
 	} > deploy/admission-policies.yaml
 	@echo "✓ Combined admission policies file generated: deploy/admission-policies.yaml"
 
+pin-release-images: ## Rewrite the generated release manifests to pin the operator image by digest (P2-8)
+	$(if $(VERSION),,$(error VERSION is required, e.g. make pin-release-images VERSION=v0.1.0))
+	@echo "Resolving multi-arch digest for $(REGISTRY)/$(IMAGE_REPOSITORY):$(VERSION)..."
+	@digest=$$(docker buildx imagetools inspect "$(REGISTRY)/$(IMAGE_REPOSITORY):$(VERSION)" --raw 2>/dev/null | sha256sum | awk '{print "sha256:"$$1}'); 	empty="sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; 	if [ -z "$$digest" ] || [ "$$digest" = "$$empty" ]; then 	  echo "ERROR: could not resolve a digest for $(REGISTRY)/$(IMAGE_REPOSITORY):$(VERSION)."; 	  echo "       The image must be BUILT AND PUSHED before manifests can be digest-pinned."; 	  exit 1; 	fi; 	echo "  digest: $$digest"; 	for f in deploy/install.yaml deploy/scout.yaml; do 	  [ -f "$$f" ] || { echo "ERROR: $$f not generated; run 'make release-manifests' first"; exit 1; }; 	  sed -i.bak -E "s|image: $(REGISTRY)/$(IMAGE_REPOSITORY)[:@][^\"[:space:]]*|image: $(REGISTRY)/$(IMAGE_REPOSITORY)@$$digest|g" "$$f"; 	  rm -f "$$f.bak"; 	  if grep -q "image: $(REGISTRY)/$(IMAGE_REPOSITORY):" "$$f"; then 	    echo "ERROR: $$f still contains a tag reference after pinning"; exit 1; 	  fi; 	  echo "  ✓ pinned $$f"; 	done
+	@echo "✓ Release manifests pinned by digest."
+
 release-manifests: install-yaml scout-yaml admission-policies-yaml ## Generate all release manifests (install.yaml + scout.yaml + admission-policies.yaml) for a given VERSION
 	@echo "✓ All release manifests generated for version $(VERSION)"
 
@@ -225,7 +231,10 @@ admission-policies-install: ## Install bindy ValidatingAdmissionPolicies (k8s 1.
 	@kubectl apply -f deploy/admission-policies/14-bindy-record-value-binding.yaml
 	@kubectl apply -f deploy/admission-policies/15-bindy-image-provenance-policy.yaml
 	@kubectl apply -f deploy/admission-policies/16-bindy-image-provenance-binding.yaml
+	@kubectl apply -f deploy/admission-policies/17-bindy-configmap-integrity-policy.yaml
+	@kubectl apply -f deploy/admission-policies/18-bindy-configmap-integrity-binding.yaml
 	@echo "✓ Admission policies installed (07/08 pod-shape, 11/12 operator-workload-SA,"
+	@echo "  17/18 ConfigMap integrity,"
 	@echo "  15/16 image-provenance included — 11/12 is the compensating control for the"
 	@echo "  cluster-wide operator Deployment grant, so it must not be skipped)."
 	@echo "  Opt-in (breaking for clusters with existing hmac-sha1 RNDC keys):"

--- a/deploy/admission-policies/17-bindy-configmap-integrity-policy.yaml
+++ b/deploy/admission-policies/17-bindy-configmap-integrity-policy.yaml
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# ValidatingAdmissionPolicy: protect operator-generated ConfigMaps from tampering.
+# Closes audit finding P2-2 / threat T3 (ConfigMap tampering).
+#
+# WHY NOT `immutable: true`:
+# The obvious fix — setting `immutable: true` on generated ConfigMaps — is wrong
+# here. These ConfigMaps carry named.conf and are MOUNTED AS VOLUMES by the BIND9
+# operand pods. The kubelet deliberately stops watching an immutable ConfigMap
+# (that is the feature: it saves API server load), so marking them immutable would
+# mean a DNS configuration change could no longer reach a running pod at all. The
+# operator would have to delete and recreate the ConfigMap and then restart every
+# operand pod to apply any zone or ACL change — converting a live config update
+# into a rolling DNS outage. In a banking environment that trades a tampering risk
+# for an availability risk, which is not a good trade.
+#
+# This policy gets the same tamper-resistance without that cost: the ConfigMaps
+# stay mutable for the OPERATOR, and become effectively read-only for everybody
+# else. A namespace tenant who can write ConfigMaps can no longer rewrite
+# named.conf underneath a running DNS server.
+#
+# Scope: matches only ConfigMaps labelled `app.kubernetes.io/part-of: bindy`,
+# i.e. those the operator generated (`build_labels_from_instance`). Tenant-authored
+# ConfigMaps — including the custom ones referenced by `spec.configMapRefs` — are
+# not labelled this way and are unaffected.
+#
+# Requires Kubernetes 1.30+ (admissionregistration.k8s.io/v1 GA).
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: bindy-configmap-integrity
+  labels:
+    app.kubernetes.io/name: bindy
+    app.kubernetes.io/part-of: bindy
+    app.kubernetes.io/component: admission-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["UPDATE", "DELETE"]
+        resources: ["configmaps"]
+    # Only bindy-generated ConfigMaps.
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/part-of: bindy
+  matchConditions:
+    # Exempt the operator itself — it is the legitimate writer.
+    - name: not-the-operator
+      expression: >-
+        request.userInfo.username != 'system:serviceaccount:bindy-system:bindy'
+    # Exempt Kubernetes' own garbage collector and namespace controller, which
+    # must be able to delete these objects when an owner or namespace goes away.
+    - name: not-kube-controller
+      expression: >-
+        !(request.userInfo.username in [
+          'system:serviceaccount:kube-system:generic-garbage-collector',
+          'system:serviceaccount:kube-system:namespace-controller'
+        ])
+  validations:
+    - expression: "false"
+      message: >-
+        This ConfigMap is generated and owned by the bindy operator
+        (app.kubernetes.io/part-of: bindy) and carries live BIND9 configuration.
+        It may only be modified by the operator ServiceAccount. Change the owning
+        Bind9Instance / Bind9Cluster spec instead, or use spec.configMapRefs to
+        supply your own ConfigMap.

--- a/deploy/admission-policies/18-bindy-configmap-integrity-binding.yaml
+++ b/deploy/admission-policies/18-bindy-configmap-integrity-binding.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# Binding for bindy-configmap-integrity (audit finding P2-2 / threat T3).
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: bindy-configmap-integrity-binding
+  labels:
+    app.kubernetes.io/name: bindy
+    app.kubernetes.io/part-of: bindy
+    app.kubernetes.io/component: admission-policy
+spec:
+  policyName: bindy-configmap-integrity
+  validationActions: ["Deny"]

--- a/deploy/operator/rbac/namespaced/README.md
+++ b/deploy/operator/rbac/namespaced/README.md
@@ -1,0 +1,73 @@
+# Namespace-scoped operator RBAC
+
+Least-privilege RBAC for running bindy with `BINDY_WATCH_NAMESPACES` set. Closes
+audit findings **C2** (cluster-wide `deployments create/update/patch`, a
+privilege-escalation path via `serviceAccountName`) and **H3** (cluster-wide
+`secrets get/list/watch`) by construction rather than by compensating control.
+
+**This is opt-in.** The default deployment (`BINDY_WATCH_NAMESPACES` unset) is
+unchanged and still uses the cluster-wide `../role.yaml` + `../rolebinding.yaml`.
+
+## What is here
+
+| File | Scope | Purpose |
+|---|---|---|
+| `clusterrole.yaml` | Cluster | `clusterbind9providers` get/list/watch/update/patch **only** |
+| `clusterrolebinding.yaml` | Cluster | Binds the above to the `bindy` SA |
+| `role.yaml` | Namespaced | Everything else — apply one copy per watched namespace |
+| `rolebinding.yaml` | Namespaced | Binds that Role to the `bindy` SA, per namespace |
+
+### Why a ClusterRole survives at all
+
+`ClusterBind9Provider` is the only bindy kind with `scope: Cluster`. A cluster-scoped
+object has no namespace to scope a watch to, so a slim ClusterRole is irreducible.
+Every other kind — including `Bind9Cluster`, which earlier analysis wrongly listed as
+cluster-scoped — is `Namespaced` and moves into the per-namespace Role.
+
+So M-22's original claim that scoping "eliminates cluster-wide access entirely" is not
+achievable. What it *does* eliminate is cluster-wide **Secret read** and cluster-wide
+**workload write**, which is what C2 and H3 are actually about.
+
+## Installing
+
+```sh
+NAMESPACES="tenant-a tenant-b"
+
+# 1. The irreducible cluster-scoped grant (once).
+kubectl apply -f clusterrole.yaml -f clusterrolebinding.yaml
+
+# 2. One Role + RoleBinding per watched namespace.
+for ns in $NAMESPACES; do
+  sed "s/REPLACE_NAMESPACE/$ns/" role.yaml        | kubectl apply -f -
+  sed "s/REPLACE_NAMESPACE/$ns/" rolebinding.yaml | kubectl apply -f -
+done
+
+# 3. Point the operator at the same list.
+kubectl set env deployment/bindy -n bindy-system \
+  BINDY_WATCH_NAMESPACES="$(echo $NAMESPACES | tr ' ' ',')"
+
+# 4. Remove the cluster-wide binding this replaces.
+kubectl delete clusterrolebinding bindy-rolebinding
+```
+
+> **The namespace list in step 2 must match step 3 exactly.** If the operator watches
+> a namespace with no Role, it crash-loops on 403s. If a Role exists for a namespace
+> the operator does not watch, that is a silent over-grant.
+
+## Leader election
+
+The lease lives in `BINDY_LEASE_NAMESPACE` (default `bindy-system`), which is
+independent of the watched set. If your lease namespace is not in
+`BINDY_WATCH_NAMESPACES`, apply `role.yaml`/`rolebinding.yaml` there too — or grant a
+dedicated lease-only Role.
+
+## Keeping this in sync
+
+These files are **derived from `../role.yaml`** by splitting its rules on whether the
+resource is cluster-scoped. When you change `../role.yaml`, re-split it: the split is
+`clusterbind9providers` and `clusterbind9providers/status` into `clusterrole.yaml`,
+everything else into `role.yaml`.
+
+`src/bootstrap_tests.rs` asserts the split stays faithful — that the namespaced Role
+grants no cluster-scoped kind, and that the two halves together cover every rule in
+`../role.yaml`.

--- a/deploy/operator/rbac/namespaced/clusterrole.yaml
+++ b/deploy/operator/rbac/namespaced/clusterrole.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# DO NOT EDIT BY HAND — derived from deploy/operator/rbac/role.yaml.
+# If you change role.yaml, re-split it (see README.md in this directory).
+#
+# The IRREDUCIBLE cluster-wide grant. ClusterBind9Provider is the only bindy
+# kind with `scope: Cluster`, so it can never be watched per-namespace and a
+# namespace-scoped operator still needs this. Note what is NOT here: no
+# cluster-wide Secret read (audit H3), no cluster-wide Deployment write (C2).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bindy-role-cluster
+  labels: {app.kubernetes.io/name: bindy, app.kubernetes.io/component: rbac}
+rules:
+- apiGroups: [bindy.firestoned.io]
+  resources: [clusterbind9providers]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [bindy.firestoned.io]
+  resources: [clusterbind9providers/status]
+  verbs: [get, update, patch]

--- a/deploy/operator/rbac/namespaced/clusterrolebinding.yaml
+++ b/deploy/operator/rbac/namespaced/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# DO NOT EDIT BY HAND — derived from deploy/operator/rbac/role.yaml.
+# If you change role.yaml, re-split it (see README.md in this directory).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bindy-rolebinding-cluster
+  labels: {app.kubernetes.io/name: bindy, app.kubernetes.io/component: rbac}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: bindy-role-cluster}
+subjects:
+- {kind: ServiceAccount, name: bindy, namespace: bindy-system}

--- a/deploy/operator/rbac/namespaced/role.yaml
+++ b/deploy/operator/rbac/namespaced/role.yaml
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# DO NOT EDIT BY HAND — derived from deploy/operator/rbac/role.yaml.
+# If you change role.yaml, re-split it (see README.md in this directory).
+#
+# Apply ONE COPY PER WATCHED NAMESPACE, with metadata.namespace set to that
+# namespace and a matching RoleBinding. The namespace list must equal
+# BINDY_WATCH_NAMESPACES on the operator Deployment, or the operator will watch
+# a namespace it cannot read and crash-loop on 403s.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bindy-role
+  namespace: REPLACE_NAMESPACE
+  labels: {app.kubernetes.io/name: bindy, app.kubernetes.io/component: rbac}
+rules:
+- apiGroups: [bindy.firestoned.io]
+  resources: [bind9instances]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: [bindy.firestoned.io]
+  resources: [bind9instances/status]
+  verbs: [get, update, patch]
+- apiGroups: [bindy.firestoned.io]
+  resources: [bind9clusters]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: [bindy.firestoned.io]
+  resources: [bind9clusters/status]
+  verbs: [get, update, patch]
+- apiGroups: [bindy.firestoned.io]
+  resources: [dnszones]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [bindy.firestoned.io]
+  resources: [dnszones/status]
+  verbs: [get, update, patch]
+- apiGroups: [bindy.firestoned.io]
+  resources: [arecords, aaaarecords, txtrecords, cnamerecords, mxrecords, nsrecords, srvrecords, caarecords,
+    ptrrecords]
+  verbs: [get, list, watch, update, patch]
+- apiGroups: [bindy.firestoned.io]
+  resources: [arecords/status, aaaarecords/status, txtrecords/status, cnamerecords/status, mxrecords/status,
+    nsrecords/status, srvrecords/status, caarecords/status, ptrrecords/status]
+  verbs: [get, update, patch]
+- apiGroups: [apps]
+  resources: [deployments]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: ['']
+  resources: [services]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: ['']
+  resources: [secrets]
+  verbs: [get, list, watch]
+- apiGroups: ['']
+  resources: [serviceaccounts]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [get, list, watch]
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch]
+- apiGroups: ['']
+  resources: [events]
+  verbs: [create, patch]
+- apiGroups: [coordination.k8s.io]
+  resources: [leases]
+  verbs: [get, create, update, patch]

--- a/deploy/operator/rbac/namespaced/rolebinding.yaml
+++ b/deploy/operator/rbac/namespaced/rolebinding.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Erick Bourgeois, firestoned
+# SPDX-License-Identifier: MIT
+#
+# DO NOT EDIT BY HAND — derived from deploy/operator/rbac/role.yaml.
+# If you change role.yaml, re-split it (see README.md in this directory).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bindy-rolebinding
+  namespace: REPLACE_NAMESPACE
+  labels: {app.kubernetes.io/name: bindy, app.kubernetes.io/component: rbac}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: bindy-role}
+subjects:
+- {kind: ServiceAccount, name: bindy, namespace: bindy-system}

--- a/deploy/pod-hardening.yaml
+++ b/deploy/pod-hardening.yaml
@@ -58,7 +58,20 @@ spec:
         - port: 5353
           protocol: UDP
     # bindcar HTTP API: container port 8080 and Service port 80.
-    - ports:
+    #
+    # RESTRICTED TO THE OPERATOR. This rule previously had no `from:` selector, so
+    # every pod in the cluster could reach the bindcar API. Only the operator has any
+    # legitimate reason to call it, so it is now scoped to the operator pod — ordinary
+    # least privilege for a management API.
+    #
+    # Keep this rule in place. Enforcing it is a prerequisite for the transport
+    # hardening tracked for the bindcar sidecar; do not widen the selector without
+    # reviewing that work first.
+    - from:
+        - podSelector:
+            matchLabels:
+              app: bindy
+      ports:
         - port: 8080
           protocol: TCP
         - port: 80

--- a/docs/src/operations/env-vars.md
+++ b/docs/src/operations/env-vars.md
@@ -13,6 +13,38 @@ Configure Bindy using environment variables. See also the [CLI Reference](../ref
 | `BINDY_KUBE_QPS` | `50.0` | API server request rate (queries per second). |
 | `BINDY_KUBE_BURST` | `100` | API server burst cap above QPS. |
 
+### Namespace Scoping
+
+| Variable | Default | Description |
+|---|---|---|
+| `BINDY_WATCH_NAMESPACES` | *(unset — cluster-wide)* | Comma-separated list of namespaces to watch, e.g. `tenant-a,tenant-b`. When set, the operator builds one watch and one controller **per namespace** (`Api::namespaced`) and needs only a `Role`/`RoleBinding` in each, instead of a cluster-wide `ClusterRoleBinding`. |
+
+Leaving this unset is the default and keeps the operator cluster-wide, exactly as
+before. Setting it is a deliberate opt-in that **also requires applying the namespaced
+RBAC** — see [`deploy/operator/rbac/namespaced/README.md`](https://github.com/firestoned/bindy/blob/main/deploy/operator/rbac/namespaced/README.md).
+
+!!! warning "The namespace list and the RBAC must match exactly"
+    If the operator watches a namespace with no `Role`, it crash-loops on 403s. If a
+    `Role` exists for a namespace the operator does not watch, that is a silent
+    over-grant. Change both together.
+
+**What this buys you.** With the cluster-wide `ClusterRoleBinding` removed, the
+operator ServiceAccount can no longer read `Secrets` or create workloads outside the
+watched namespaces. That closes the two findings behind the cluster-wide deployment:
+a compromised operator token can no longer read every Secret in the cluster, nor
+create a Deployment whose pod template names a privileged ServiceAccount.
+
+**What it does not buy you.** A slim `ClusterRole` remains, granting
+`get/list/watch` on `clusterbind9providers`. `ClusterBind9Provider` is the only bindy
+kind with `scope: Cluster`, and a cluster-scoped object has no namespace to scope a
+watch to. So this reduces cluster-wide access to a single read-only CRD; it does not
+eliminate cluster-wide access entirely.
+
+!!! note "Leader election is independent"
+    The lease lives in `BINDY_LEASE_NAMESPACE` (default `bindy-system`), which is not
+    required to be in the watched set. If it is not, apply the namespaced `Role` and
+    `RoleBinding` there too, or grant a dedicated lease-only Role.
+
 ### Leader Election
 
 | Variable | Default | Description |

--- a/docs/src/security/threat-model.md
+++ b/docs/src/security/threat-model.md
@@ -676,7 +676,7 @@ just the one kubeconfig Secret it legitimately needs for multi-cluster mode.
 **Likelihood:** LOW (requires compromising the Scout pod/token specifically), but
 **this had the largest blast radius of any threat in this document** — worse than
 compromising the main operator, whose Secret access is namespace-scoped for
-mutation (B-5) — though the operator's Secret *read* is still cluster-wide, see M-22.
+mutation (B-5) and — when `BINDY_WATCH_NAMESPACES` is set — for read as well (M-22).
 
 **Original finding:** Scout's `ClusterRole` (`deploy/scout/clusterrole.yaml`) granted
 `apiGroups: [""], resources: ["secrets"], verbs: ["get"]` with **no `resourceNames`
@@ -829,13 +829,15 @@ kubeconfig Secret, in deployments that use Phase 2 mode at all.
 - ✅ **B-5 hardening:** operator's cluster-wide Secret access reduced to
   read-only; mutating verbs confined to a namespaced Role in the operator's own
   namespace (see T3)
-- ⛔ **Namespace-scoped operator mode — NOT IMPLEMENTED.** `BINDY_WATCH_NAMESPACES`
-  is parsed by `src/namespace_scope.rs` but **nothing consumes it**: `src/main.rs`
-  does not reference `NamespaceScope` and builds every watch cluster-wide. Setting
-  the variable today has no effect. The operator is cluster-wide in every
-  deployment. Tracked as audit finding P1-2; the compensating control for the
-  resulting Deployment-create escalation is VAP 11/12
-  (`deploy/admission-policies/11-bindy-operator-workload-sa-policy.yaml`)
+- ✅ **Namespace-scoped operator mode (opt-in):** set `BINDY_WATCH_NAMESPACES` to a
+  comma-separated namespace list and the operator builds one watch and one controller
+  per namespace (`Api::namespaced`), needing only a Role + RoleBinding in each. With
+  the cluster-wide ClusterRoleBinding removed, the operator SA can no longer read
+  Secrets or create workloads outside the watched set — closing C2 and H3 by
+  construction rather than by compensating control. VAP 11/12 remains as
+  defence-in-depth, and is still the only mitigation in the default cluster-wide
+  deployment. **Default is unchanged:** unset means cluster-wide, exactly as before.
+  Install guide: `deploy/operator/rbac/namespaced/README.md`
   (unset = watch everything), so this mitigation is not yet load-bearing unless
   a deployer explicitly configures it.
 - ✅ Automated RBAC verification script (`deploy/rbac/verify-rbac.sh`)
@@ -1291,7 +1293,7 @@ tampering (T4), not cluster-wide Secret exposure.
 | M-09 | SBOM generation | T2 (supply chain) | ✅ SLSA Level 2 |
 | M-10 | Chainguard zero-CVE images | I3 (CVE disclosure) | ✅ Container security |
 | M-21 | **B-5 Secret RBAC split** (2026-06-30): operator's cluster-wide `ClusterRole` is read-only on Secrets; mutating verbs moved to a namespaced Role bound only in the operator's own namespace | T3 (Secret tampering), E2 (privilege escalation) | ✅ RBAC |
-| M-22 | **Namespace-scoped operator mode** (`BINDY_WATCH_NAMESPACES`) | E2, R2, I1 | ⛔ **NOT IMPLEMENTED** — the env var is parsed but unused (`src/main.rs` never imports `NamespaceScope`); setting it has no effect. Audit finding P1-2. When built, it can eliminate cluster-wide Secret/workload access, but **not** cluster-wide access entirely — `Bind9Cluster` and `ClusterBind9Provider` are cluster-scoped kinds and will always need a slim ClusterRole |
+| M-22 | **Namespace-scoped operator mode** (opt-in via `BINDY_WATCH_NAMESPACES`): every watch is built per-namespace and the operator needs only Role/RoleBinding in each watched namespace | E2, R2, I1 | ✅ **Implemented** (opt-in; default remains cluster-wide). Eliminates cluster-wide Secret read (H3) and cluster-wide workload write (C2) — verified with `kubectl auth can-i`. A slim ClusterRole remains for `clusterbind9providers`, the only cluster-scoped bindy kind, so this does **not** eliminate cluster-wide access *entirely*. See `deploy/operator/rbac/namespaced/README.md` |
 | M-23 | **Unprivileged DNS port + capability drop**: BIND9 operand binds container port 5353 (Service still exposes 53) and adds zero Linux capabilities (`NET_BIND_SERVICE` removed) | E1 (container escape) | ✅ Pod Security |
 | M-24 | **ValidatingAdmissionPolicy suite** (8 policies + 8 bindings = 16 manifests, as of 2026-07-01): ACL syntax, zone-name validation, RNDC strictness, operand pod shape, DNSSEC policy, operator-workload ServiceAccount identity, DNS record value validation, image provenance, and `volumeMount.mountPath` allow-listing (`safe_volume.rs`, closes audit finding F-001) | T1 (DNS tampering), T3 (ConfigMap/Secret tampering), E1 (container escape via malicious volume mounts), T2 (image provenance) | ✅ Kubernetes VAP — supersedes M-13 below |
 | M-30 | **Scout namespace whitelisting** (`--namespace-selector` / `BINDY_SCOUT_NAMESPACE_SELECTOR`, new in v1.1): a source object's namespace must match a configured Kubernetes label selector *in addition to* the object's own opt-in annotation before Scout acts on it. Label-selector matching delegates to the API server (no client-side selector parser). Reduces Scout's day-to-day operating footprint — bounds T4 (cross-tenant patch/update) during normal operation. **Does not reduce the `ClusterRole`'s RBAC ceiling** for Ingress/Service/route types — a directly compromised token is unaffected for those. **Opt-in — unset by default**, matching pre-v1.1 behavior for backward compatibility; Scout logs a startup warning when unset. See the Scout guide's "Namespace Whitelisting" section for the rollout/migration note. | T4 (partial) | ⚠️ Opt-in, recommended for all production deployments |

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -117,6 +117,19 @@ pub const DEFAULT_IMAGE_TAG: &str = concat!("v", env!("CARGO_PKG_VERSION"));
 pub const BINDY_ROLE_YAML: &str = include_str!("../deploy/operator/rbac/role.yaml");
 pub const BINDY_ADMIN_ROLE_YAML: &str = include_str!("../deploy/operator/rbac/role-admin.yaml");
 
+/// Namespace-scoped split of [`BINDY_ROLE_YAML`]: the irreducible cluster-scoped half.
+///
+/// Used when the operator runs with `BINDY_WATCH_NAMESPACES` set. Contains only
+/// `clusterbind9providers` — the one bindy kind with `scope: Cluster`.
+pub const BINDY_NAMESPACED_CLUSTER_ROLE_YAML: &str =
+    include_str!("../deploy/operator/rbac/namespaced/clusterrole.yaml");
+
+/// Namespace-scoped split of [`BINDY_ROLE_YAML`]: the per-namespace half.
+///
+/// Applied once per watched namespace, with `metadata.namespace` substituted.
+pub const BINDY_NAMESPACED_ROLE_YAML: &str =
+    include_str!("../deploy/operator/rbac/namespaced/role.yaml");
+
 /// Embedded TokenReview ClusterRole (bindcar `0.7.0` Mode B).
 ///
 /// Grants `create tokenreviews` so the bindcar sidecar (running as the operand

--- a/src/bootstrap_tests.rs
+++ b/src/bootstrap_tests.rs
@@ -14,15 +14,16 @@ mod tests {
         build_tokenreview_cluster_role_binding, parse_cluster_role, resolve_image,
         ScoutDeploymentOptions, BINDCAR_TOKENREVIEW_CLUSTER_ROLE_YAML, BINDCAR_TOKENREVIEW_NAME,
         BINDCAR_TOKEN_EXPIRATION_SECONDS, BINDCAR_TOKEN_FILENAME, BINDCAR_TOKEN_MOUNT_PATH,
-        BINDCAR_TOKEN_VOLUME_NAME, BINDY_ADMIN_ROLE_YAML, BINDY_ROLE_YAML,
-        CLUSTER_ROLE_BINDING_NAME, DEFAULT_IMAGE_TAG, DEFAULT_NAMESPACE,
-        DEFAULT_SCOUT_CLUSTER_NAME, MC_DEFAULT_SERVICE_ACCOUNT_NAME, OPERATOR_CLUSTER_ROLE_YAMLS,
-        OPERATOR_DEPLOYMENT_NAME, OPERATOR_IMAGE_BASE, OPERATOR_ROLE_NAME, POD_NAMESPACE_ENV,
-        REMOTE_KUBECONFIG_SECRET_SUFFIX, REMOTE_KUBECONFIG_SECRET_TYPE, SA_TOKEN_SECRET_SUFFIX,
-        SCOUT_CLUSTER_ROLE_BINDING_NAME, SCOUT_CLUSTER_ROLE_NAME, SCOUT_DEPLOYMENT_NAME,
-        SCOUT_SECRETS_READER_ROLE_BINDING_NAME, SCOUT_SECRETS_READER_ROLE_NAME,
-        SCOUT_SERVICE_ACCOUNT_NAME, SCOUT_WRITER_ROLE_BINDING_NAME, SCOUT_WRITER_ROLE_NAME,
-        SECRETS_WRITER_ROLE_BINDING_NAME, SECRETS_WRITER_ROLE_NAME, SERVICE_ACCOUNT_NAME,
+        BINDCAR_TOKEN_VOLUME_NAME, BINDY_ADMIN_ROLE_YAML, BINDY_NAMESPACED_CLUSTER_ROLE_YAML,
+        BINDY_NAMESPACED_ROLE_YAML, BINDY_ROLE_YAML, CLUSTER_ROLE_BINDING_NAME, DEFAULT_IMAGE_TAG,
+        DEFAULT_NAMESPACE, DEFAULT_SCOUT_CLUSTER_NAME, MC_DEFAULT_SERVICE_ACCOUNT_NAME,
+        OPERATOR_CLUSTER_ROLE_YAMLS, OPERATOR_DEPLOYMENT_NAME, OPERATOR_IMAGE_BASE,
+        OPERATOR_ROLE_NAME, POD_NAMESPACE_ENV, REMOTE_KUBECONFIG_SECRET_SUFFIX,
+        REMOTE_KUBECONFIG_SECRET_TYPE, SA_TOKEN_SECRET_SUFFIX, SCOUT_CLUSTER_ROLE_BINDING_NAME,
+        SCOUT_CLUSTER_ROLE_NAME, SCOUT_DEPLOYMENT_NAME, SCOUT_SECRETS_READER_ROLE_BINDING_NAME,
+        SCOUT_SECRETS_READER_ROLE_NAME, SCOUT_SERVICE_ACCOUNT_NAME, SCOUT_WRITER_ROLE_BINDING_NAME,
+        SCOUT_WRITER_ROLE_NAME, SECRETS_WRITER_ROLE_BINDING_NAME, SECRETS_WRITER_ROLE_NAME,
+        SERVICE_ACCOUNT_NAME,
     };
 
     /// Convenience helper: build a minimal `ScoutDeploymentOptions` for tests.
@@ -195,6 +196,80 @@ mod tests {
                 "operator ClusterRole must NOT grant cluster-wide secrets '{forbidden}'"
             );
         }
+    }
+
+    // --- P1-2: the namespace-scoped RBAC split must stay faithful ---
+
+    /// The only bindy kind with `scope: Cluster`. Everything else is Namespaced and
+    /// therefore belongs in the per-namespace Role.
+    const CLUSTER_SCOPED_KINDS: [&str; 2] =
+        ["clusterbind9providers", "clusterbind9providers/status"];
+
+    fn parse_role_rules(yaml: &str) -> Vec<k8s_openapi::api::rbac::v1::PolicyRule> {
+        let doc: serde_yaml::Value = serde_yaml::from_str(yaml).expect("valid RBAC YAML");
+        serde_yaml::from_value(doc["rules"].clone()).expect("rules parse")
+    }
+
+    fn rule_resources(rules: &[k8s_openapi::api::rbac::v1::PolicyRule]) -> Vec<String> {
+        rules
+            .iter()
+            .flat_map(|r| r.resources.clone().unwrap_or_default())
+            .collect()
+    }
+
+    /// The namespaced Role must not grant any cluster-scoped kind — a Role cannot
+    /// authorize one, so such a rule would be silently dead and misleading.
+    #[test]
+    fn test_namespaced_role_grants_no_cluster_scoped_kind() {
+        let resources = rule_resources(&parse_role_rules(BINDY_NAMESPACED_ROLE_YAML));
+        for kind in CLUSTER_SCOPED_KINDS {
+            assert!(
+                !resources.iter().any(|r| r == kind),
+                "namespaced Role must not grant cluster-scoped {kind}"
+            );
+        }
+    }
+
+    /// The slim ClusterRole must grant ONLY cluster-scoped kinds. Anything else here
+    /// re-introduces exactly the cluster-wide access this split exists to remove —
+    /// a `secrets` or `deployments` rule would silently undo audit findings H3 and C2.
+    #[test]
+    fn test_namespaced_clusterrole_grants_only_cluster_scoped_kinds() {
+        let resources = rule_resources(&parse_role_rules(BINDY_NAMESPACED_CLUSTER_ROLE_YAML));
+        assert!(
+            !resources.is_empty(),
+            "the slim ClusterRole must not be empty"
+        );
+        for r in &resources {
+            assert!(
+                CLUSTER_SCOPED_KINDS.contains(&r.as_str()),
+                "slim ClusterRole must not grant {r} — only cluster-scoped kinds belong here"
+            );
+        }
+    }
+
+    /// The two halves together must cover every resource the cluster-wide role grants.
+    /// Without this, adding a rule to role.yaml and forgetting the split would quietly
+    /// drop a permission in scoped mode — visible only as a 403 at runtime.
+    #[test]
+    fn test_namespaced_split_covers_every_cluster_wide_resource() {
+        let full: std::collections::BTreeSet<String> =
+            rule_resources(&parse_role_rules(BINDY_ROLE_YAML))
+                .into_iter()
+                .collect();
+        let mut split: std::collections::BTreeSet<String> =
+            rule_resources(&parse_role_rules(BINDY_NAMESPACED_ROLE_YAML))
+                .into_iter()
+                .collect();
+        split.extend(rule_resources(&parse_role_rules(
+            BINDY_NAMESPACED_CLUSTER_ROLE_YAML,
+        )));
+
+        let missing: Vec<_> = full.difference(&split).collect();
+        assert!(
+            missing.is_empty(),
+            "these resources are granted cluster-wide but missing from the namespaced split: {missing:?}"
+        );
     }
 
     // --- P3-2 / least privilege: no `create` on user-authored kinds ---

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,6 +22,75 @@ use kube::{Client, ResourceExt};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+/// A reflector view over one or more namespace-scoped watches.
+///
+/// When the operator runs cluster-wide ([`NamespaceScope::All`]) this holds exactly
+/// one shard built from `Api::all`, and every operation is a direct pass-through —
+/// the cluster-wide deployment behaves exactly as it did before namespace scoping
+/// existed.
+///
+/// When the operator is scoped to a namespace set it holds **one shard per
+/// namespace**. That sharding is load-bearing, not an implementation detail: a
+/// single reflector `Store` cannot be fed by several namespace watches merged with
+/// `select_all`, because `watcher::Event::InitDone` makes the store *replace* its
+/// entire contents with the buffer of whichever watch just finished listing
+/// (`kube_runtime::reflector::store` does `mem::swap(&mut *store, &mut self.buffer)`).
+/// Merging N watches into one writer would leave the store holding only the last
+/// namespace to sync — silently, and again on every watch reconnect. Sharding keeps
+/// each watch's `Init`/`InitDone` cycle confined to its own store.
+///
+/// [`NamespaceScope::All`]: crate::namespace_scope::NamespaceScope::All
+#[derive(Clone)]
+pub struct MultiStore<K>
+where
+    K: kube::Resource + Clone + 'static,
+    K::DynamicType: std::hash::Hash + Eq + Clone + std::fmt::Debug + Default,
+{
+    shards: Vec<Store<K>>,
+}
+
+impl<K> MultiStore<K>
+where
+    K: kube::Resource + Clone + 'static,
+    K::DynamicType: std::hash::Hash + Eq + Clone + std::fmt::Debug + Default,
+{
+    /// Build a view over the given shards.
+    ///
+    /// # Panics
+    /// Panics if `shards` is empty. An empty view would make every lookup return
+    /// nothing while the operator reported itself healthy — a far worse failure
+    /// than a loud one at startup.
+    #[must_use]
+    pub fn new(shards: Vec<Store<K>>) -> Self {
+        assert!(
+            !shards.is_empty(),
+            "MultiStore requires at least one shard; an empty view would silently \
+             make every reflector lookup return nothing"
+        );
+        Self { shards }
+    }
+
+    /// All objects across every shard.
+    ///
+    /// Shards are disjoint by construction (one namespace each, or a single
+    /// cluster-wide shard), so no de-duplication is needed.
+    #[must_use]
+    pub fn state(&self) -> Vec<Arc<K>> {
+        // Fast path: the cluster-wide default is a single shard. Return its state
+        // directly so the default deployment allocates exactly as it did before.
+        if let [only] = self.shards.as_slice() {
+            return only.state();
+        }
+        self.shards.iter().flat_map(Store::state).collect()
+    }
+
+    /// Number of shards backing this view (1 when cluster-wide).
+    #[must_use]
+    pub fn shard_count(&self) -> usize {
+        self.shards.len()
+    }
+}
+
 /// Shared context passed to all operators.
 ///
 /// This context provides access to:
@@ -42,6 +111,15 @@ pub struct Context {
 
     /// Metrics registry for observability
     pub metrics: Metrics,
+
+    /// The set of namespaces this operator watches and manages.
+    ///
+    /// Drives how every controller builds its `Api` handles: [`NamespaceScope::All`]
+    /// (the default) uses `Api::all` and needs cluster-wide RBAC, while a namespace
+    /// list uses `Api::namespaced` per namespace and needs only RoleBindings.
+    ///
+    /// [`NamespaceScope::All`]: crate::namespace_scope::NamespaceScope::All
+    pub namespace_scope: crate::namespace_scope::NamespaceScope,
 }
 
 /// Collection of all reflector stores for cross-operator queries.
@@ -51,24 +129,24 @@ pub struct Context {
 #[derive(Clone)]
 pub struct Stores {
     // Cluster-scoped resources
-    pub cluster_bind9_providers: Store<ClusterBind9Provider>,
+    pub cluster_bind9_providers: MultiStore<ClusterBind9Provider>,
 
     // Namespace-scoped resources
-    pub bind9_clusters: Store<Bind9Cluster>,
-    pub bind9_instances: Store<Bind9Instance>,
-    pub bind9_deployments: Store<Deployment>,
-    pub dnszones: Store<DNSZone>,
+    pub bind9_clusters: MultiStore<Bind9Cluster>,
+    pub bind9_instances: MultiStore<Bind9Instance>,
+    pub bind9_deployments: MultiStore<Deployment>,
+    pub dnszones: MultiStore<DNSZone>,
 
     // DNS Record types
-    pub a_records: Store<ARecord>,
-    pub aaaa_records: Store<AAAARecord>,
-    pub cname_records: Store<CNAMERecord>,
-    pub txt_records: Store<TXTRecord>,
-    pub mx_records: Store<MXRecord>,
-    pub ns_records: Store<NSRecord>,
-    pub srv_records: Store<SRVRecord>,
-    pub caa_records: Store<CAARecord>,
-    pub ptr_records: Store<PTRRecord>,
+    pub a_records: MultiStore<ARecord>,
+    pub aaaa_records: MultiStore<AAAARecord>,
+    pub cname_records: MultiStore<CNAMERecord>,
+    pub txt_records: MultiStore<TXTRecord>,
+    pub mx_records: MultiStore<MXRecord>,
+    pub ns_records: MultiStore<NSRecord>,
+    pub srv_records: MultiStore<SRVRecord>,
+    pub caa_records: MultiStore<CAARecord>,
+    pub ptr_records: MultiStore<PTRRecord>,
 }
 
 impl Stores {

--- a/src/context_tests.rs
+++ b/src/context_tests.rs
@@ -7,6 +7,112 @@
 mod tests {
     use super::super::*;
 
+    // --- MultiStore: the sharded reflector view (P1-2) ---
+
+    use kube::runtime::reflector;
+    use kube::runtime::watcher;
+
+    /// Build a populated single-namespace shard.
+    ///
+    /// Objects are fed through a real `Init` -> `InitApply`* -> `InitDone` cycle,
+    /// because that cycle is precisely what makes merging shards unsafe — see the
+    /// `MultiStore` docs.
+    fn shard_with(names: &[(&str, &str)]) -> reflector::Store<Bind9Instance> {
+        let (store, mut writer) = reflector::store::<Bind9Instance>();
+        writer.apply_watcher_event(&watcher::Event::Init);
+        for (name, namespace) in names {
+            let instance: Bind9Instance = serde_json::from_value(serde_json::json!({
+                "apiVersion": "bindy.firestoned.io/v1beta1",
+                "kind": "Bind9Instance",
+                "metadata": { "name": name, "namespace": namespace },
+                "spec": { "clusterRef": "c", "role": "primary" }
+            }))
+            .expect("valid Bind9Instance fixture");
+            writer.apply_watcher_event(&watcher::Event::InitApply(instance));
+        }
+        writer.apply_watcher_event(&watcher::Event::InitDone);
+        store
+    }
+
+    #[test]
+    fn test_multistore_single_shard_passes_through() {
+        let store = MultiStore::new(vec![shard_with(&[("a", "ns1"), ("b", "ns1")])]);
+        assert_eq!(store.shard_count(), 1);
+        assert_eq!(store.state().len(), 2);
+    }
+
+    #[test]
+    fn test_multistore_concatenates_shards() {
+        // The whole point: two namespace shards must both be visible. A single
+        // reflector fed by two merged watches would show only one namespace here.
+        let store = MultiStore::new(vec![
+            shard_with(&[("a", "ns1")]),
+            shard_with(&[("b", "ns2"), ("c", "ns2")]),
+        ]);
+        assert_eq!(store.shard_count(), 2);
+
+        let names: Vec<String> = store
+            .state()
+            .iter()
+            .map(|i| i.metadata.name.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(names.len(), 3, "both shards must contribute: {names:?}");
+        for expected in ["a", "b", "c"] {
+            assert!(names.iter().any(|n| n == expected), "missing {expected}");
+        }
+    }
+
+    #[test]
+    fn test_multistore_resync_of_one_shard_does_not_clear_others() {
+        // This is the regression the whole sharding design exists for. Re-running a
+        // shard's Init/InitDone cycle (what happens on every watch reconnect) resets
+        // THAT shard only; a merged single-store design would wipe every namespace.
+        let shard_a = shard_with(&[("a", "ns1")]);
+        let (shard_b, mut writer_b) = reflector::store::<Bind9Instance>();
+        let store = MultiStore::new(vec![shard_a, shard_b]);
+
+        // ns2 syncs for the first time.
+        writer_b.apply_watcher_event(&watcher::Event::Init);
+        let instance: Bind9Instance = serde_json::from_value(serde_json::json!({
+            "apiVersion": "bindy.firestoned.io/v1beta1",
+            "kind": "Bind9Instance",
+            "metadata": { "name": "b", "namespace": "ns2" },
+            "spec": { "clusterRef": "c", "role": "primary" }
+        }))
+        .expect("valid Bind9Instance fixture");
+        writer_b.apply_watcher_event(&watcher::Event::InitApply(instance));
+        writer_b.apply_watcher_event(&watcher::Event::InitDone);
+
+        assert_eq!(
+            store.state().len(),
+            2,
+            "both namespaces present after ns2 sync"
+        );
+
+        // ns2 reconnects and re-lists as empty; ns1 must be untouched.
+        writer_b.apply_watcher_event(&watcher::Event::Init);
+        writer_b.apply_watcher_event(&watcher::Event::InitDone);
+
+        let remaining: Vec<String> = store
+            .state()
+            .iter()
+            .map(|i| i.metadata.name.clone().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            remaining,
+            vec!["a".to_string()],
+            "ns2's resync must not clear ns1's shard"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one shard")]
+    fn test_multistore_rejects_empty_shard_list() {
+        // An empty view would make every lookup return nothing while the operator
+        // reported healthy — fail loudly at startup instead.
+        let _ = MultiStore::<Bind9Instance>::new(vec![]);
+    }
+
     #[test]
     fn test_record_ref_name() {
         let record = RecordRef::A("test-record".to_string(), "default".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,6 +425,126 @@ async fn initialize_services() -> Result<(Client, Arc<Bind9Manager>)> {
     Ok((client, bind9_manager))
 }
 
+/// Spawn one reflector per namespace target and return a combined view.
+///
+/// `predicate` filters objects into the store; pass `|_| true` to keep everything.
+/// `Init` and `InitDone` are always passed through — they drive the store's buffer
+/// swap, and dropping them would leave the shard permanently empty.
+///
+/// Each target gets its **own** `Store`, deliberately: merging namespace watches into
+/// one writer corrupts it (see [`MultiStore`](bindy::context::MultiStore)).
+fn spawn_sharded_reflector<K, P>(
+    client: &Client,
+    scope: &bindy::namespace_scope::NamespaceScope,
+    kind: &'static str,
+    predicate: P,
+) -> bindy::context::MultiStore<K>
+where
+    K: kube::Resource<Scope = kube::core::NamespaceResourceScope>
+        + Clone
+        + std::fmt::Debug
+        + Send
+        + Sync
+        + serde::de::DeserializeOwned
+        + 'static,
+    K::DynamicType: Default + Clone + Eq + std::hash::Hash + std::fmt::Debug + Unpin,
+    P: Fn(&K) -> bool + Clone + Send + 'static,
+{
+    let mut shards = Vec::new();
+
+    for target in scope.api_targets() {
+        let api = bindy::namespace_scope::scoped_namespaced_api::<K>(client, target);
+        let (store, writer) = reflector::store();
+        shards.push(store);
+
+        let predicate = predicate.clone();
+        let shard = target.map(ToString::to_string);
+        tokio::spawn(async move {
+            let stream = watcher(api, watcher::Config::default()).filter_map(move |event| {
+                let out = match event {
+                    Ok(watcher::Event::Apply(o)) if predicate(&o) => {
+                        Some(Ok(watcher::Event::Apply(o)))
+                    }
+                    Ok(watcher::Event::Delete(o)) if predicate(&o) => {
+                        Some(Ok(watcher::Event::Delete(o)))
+                    }
+                    Ok(watcher::Event::InitApply(o)) if predicate(&o) => {
+                        Some(Ok(watcher::Event::InitApply(o)))
+                    }
+                    // Rejected by the predicate.
+                    Ok(
+                        watcher::Event::Apply(_)
+                        | watcher::Event::Delete(_)
+                        | watcher::Event::InitApply(_),
+                    ) => None,
+                    // Lifecycle events must always reach the store.
+                    Ok(other) => Some(Ok(other)),
+                    Err(e) => Some(Err(e)),
+                };
+                futures::future::ready(out)
+            });
+
+            reflector(writer, stream)
+                .for_each(|_| futures::future::ready(()))
+                .await;
+            warn!(
+                kind = kind,
+                namespace = shard.as_deref().unwrap_or("<all>"),
+                "Reflector stream ended"
+            );
+        });
+    }
+
+    bindy::context::MultiStore::new(shards)
+}
+
+/// Owned copies of the scope's namespace targets.
+///
+/// [`NamespaceScope::api_targets`] borrows the scope; controllers need targets that
+/// outlive that borrow so they can be moved into per-namespace tasks.
+///
+/// [`NamespaceScope::api_targets`]: bindy::namespace_scope::NamespaceScope::api_targets
+fn owned_targets(scope: &bindy::namespace_scope::NamespaceScope) -> Vec<Option<String>> {
+    scope
+        .api_targets()
+        .into_iter()
+        .map(|t| t.map(ToString::to_string))
+        .collect()
+}
+
+/// Spawn a single cluster-wide reflector for a **cluster-scoped** kind.
+///
+/// `ClusterBind9Provider` is the one bindy kind with `scope: Cluster`, so it can
+/// never be watched per-namespace: there is no namespace to scope to. Even a fully
+/// namespace-scoped operator therefore keeps a slim `ClusterRole` granting
+/// `get/list/watch` on `clusterbind9providers` — this is the irreducible residue of
+/// cluster-wide RBAC, and the reason M-22 cannot claim to eliminate cluster-wide
+/// access *entirely*.
+fn spawn_cluster_reflector<K>(client: &Client, kind: &'static str) -> bindy::context::MultiStore<K>
+where
+    K: kube::Resource<Scope = kube::core::ClusterResourceScope>
+        + Clone
+        + std::fmt::Debug
+        + Send
+        + Sync
+        + serde::de::DeserializeOwned
+        + 'static,
+    K::DynamicType: Default + Clone + Eq + std::hash::Hash + std::fmt::Debug + Unpin,
+{
+    let api: Api<K> = Api::all(client.clone());
+    let (store, writer) = reflector::store();
+
+    tokio::spawn(async move {
+        let stream = watcher(api, watcher::Config::default());
+        reflector(writer, stream)
+            .for_each(|_| futures::future::ready(()))
+            .await;
+        warn!(kind = kind, "Reflector stream ended");
+    });
+
+    bindy::context::MultiStore::new(vec![store])
+}
+
 /// Initialize reflectors for all CRD types and create shared context.
 ///
 /// This function creates reflector tasks for all custom resources, populating
@@ -447,208 +567,58 @@ async fn initialize_services() -> Result<(Client, Arc<Bind9Manager>)> {
 async fn initialize_shared_context(client: Client) -> Result<Arc<Context>> {
     info!("Initializing reflectors for all CRD types");
 
-    // Create APIs for all CRD types
-    let cluster_bind9_providers_api = Api::<ClusterBind9Provider>::all(client.clone());
-    let bind9_clusters_api = Api::<Bind9Cluster>::all(client.clone());
-    let bind9_instances_api = Api::<Bind9Instance>::all(client.clone());
-    let bind9_deployments_api = Api::<Deployment>::all(client.clone());
-    let dnszones_api = Api::<DNSZone>::all(client.clone());
-    let a_records_api = Api::<ARecord>::all(client.clone());
-    let aaaa_records_api = Api::<AAAARecord>::all(client.clone());
-    let cname_records_api = Api::<CNAMERecord>::all(client.clone());
-    let txt_records_api = Api::<TXTRecord>::all(client.clone());
-    let mx_records_api = Api::<MXRecord>::all(client.clone());
-    let ns_records_api = Api::<NSRecord>::all(client.clone());
-    let srv_records_api = Api::<SRVRecord>::all(client.clone());
-    let caa_records_api = Api::<CAARecord>::all(client.clone());
-    let ptr_records_api = Api::<PTRRecord>::all(client.clone());
-
-    // Create stores (will be populated by reflectors)
-    let (cluster_bind9_providers_store, cluster_bind9_providers_writer) = reflector::store();
-    let (bind9_clusters_store, bind9_clusters_writer) = reflector::store();
-    let (bind9_instances_store, bind9_instances_writer) = reflector::store();
-    let (bind9_deployments_store, bind9_deployments_writer) = reflector::store();
-    let (dnszones_store, dnszones_writer) = reflector::store();
-    let (a_records_store, a_records_writer) = reflector::store();
-    let (aaaa_records_store, aaaa_records_writer) = reflector::store();
-    let (cname_records_store, cname_records_writer) = reflector::store();
-    let (txt_records_store, txt_records_writer) = reflector::store();
-    let (mx_records_store, mx_records_writer) = reflector::store();
-    let (ns_records_store, ns_records_writer) = reflector::store();
-    let (srv_records_store, srv_records_writer) = reflector::store();
-    let (caa_records_store, caa_records_writer) = reflector::store();
-    let (ptr_records_store, ptr_records_writer) = reflector::store();
-
-    // Start reflector tasks (one per CRD type)
-    // These run in the background and continuously update the stores
-    tokio::spawn(async move {
-        let stream = watcher(cluster_bind9_providers_api, watcher::Config::default());
-        reflector(cluster_bind9_providers_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("ClusterBind9Provider reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(bind9_clusters_api, watcher::Config::default());
-        reflector(bind9_clusters_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("Bind9Cluster reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(bind9_instances_api, watcher::Config::default());
-        reflector(bind9_instances_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("Bind9Instance reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        // Filter deployments to only include those owned by Bind9Instance
-        // We'll use a streaming filter to check ownerReferences
-        let stream =
-            watcher(bind9_deployments_api, watcher::Config::default()).filter_map(
-                |event| async move {
-                    match event {
-                        Ok(watcher::Event::Apply(deployment)) => {
-                            // Check if this deployment is owned by a Bind9Instance
-                            let is_bind9_deployment =
-                                deployment.metadata.owner_references.as_ref().is_some_and(
-                                    |owners| {
-                                        owners.iter().any(|owner| owner.kind == "Bind9Instance")
-                                    },
-                                );
-
-                            if is_bind9_deployment {
-                                Some(Ok(watcher::Event::Apply(deployment)))
-                            } else {
-                                None
-                            }
-                        }
-                        Ok(watcher::Event::Delete(deployment)) => {
-                            // Also filter deleted events
-                            let is_bind9_deployment =
-                                deployment.metadata.owner_references.as_ref().is_some_and(
-                                    |owners| {
-                                        owners.iter().any(|owner| owner.kind == "Bind9Instance")
-                                    },
-                                );
-
-                            if is_bind9_deployment {
-                                Some(Ok(watcher::Event::Delete(deployment)))
-                            } else {
-                                None
-                            }
-                        }
-                        Ok(watcher::Event::InitApply(deployment)) => {
-                            // Also filter init events
-                            let is_bind9_deployment =
-                                deployment.metadata.owner_references.as_ref().is_some_and(
-                                    |owners| {
-                                        owners.iter().any(|owner| owner.kind == "Bind9Instance")
-                                    },
-                                );
-
-                            if is_bind9_deployment {
-                                Some(Ok(watcher::Event::InitApply(deployment)))
-                            } else {
-                                None
-                            }
-                        }
-                        Ok(watcher::Event::Init) => Some(Ok(watcher::Event::Init)),
-                        Ok(watcher::Event::InitDone) => Some(Ok(watcher::Event::InitDone)),
-                        Err(e) => Some(Err(e)),
-                    }
-                },
+    let scope = bindy::namespace_scope::NamespaceScope::from_env();
+    match &scope {
+        bindy::namespace_scope::NamespaceScope::All => {
+            info!("Namespace scope: ALL (cluster-wide) — requires cluster-wide RBAC");
+        }
+        bindy::namespace_scope::NamespaceScope::Namespaces(ns) => {
+            info!(
+                namespaces = ?ns,
+                "Namespace scope: RESTRICTED — one watch per namespace, needs only per-namespace RoleBindings"
             );
+        }
+    }
 
-        reflector(bind9_deployments_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("Deployment reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(dnszones_api, watcher::Config::default());
-        reflector(dnszones_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("DNSZone reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(a_records_api, watcher::Config::default());
-        reflector(a_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("ARecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(aaaa_records_api, watcher::Config::default());
-        reflector(aaaa_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("AAAARecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(cname_records_api, watcher::Config::default());
-        reflector(cname_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("CNAMERecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(txt_records_api, watcher::Config::default());
-        reflector(txt_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("TXTRecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(mx_records_api, watcher::Config::default());
-        reflector(mx_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("MXRecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(ns_records_api, watcher::Config::default());
-        reflector(ns_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("NSRecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(srv_records_api, watcher::Config::default());
-        reflector(srv_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("SRVRecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(caa_records_api, watcher::Config::default());
-        reflector(caa_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("CAARecord reflector stream ended");
-    });
-
-    tokio::spawn(async move {
-        let stream = watcher(ptr_records_api, watcher::Config::default());
-        reflector(ptr_records_writer, stream)
-            .for_each(|_| futures::future::ready(()))
-            .await;
-        warn!("PTRRecord reflector stream ended");
-    });
+    // One reflector shard per namespace target. See `MultiStore` for why these
+    // cannot be merged into a single store with `select_all`.
+    // Cluster-scoped: always one cluster-wide watch, in every scope mode.
+    let cluster_bind9_providers_store =
+        spawn_cluster_reflector::<ClusterBind9Provider>(&client, "ClusterBind9Provider");
+    let bind9_clusters_store =
+        spawn_sharded_reflector::<Bind9Cluster, _>(&client, &scope, "Bind9Cluster", |_| true);
+    let bind9_instances_store =
+        spawn_sharded_reflector::<Bind9Instance, _>(&client, &scope, "Bind9Instance", |_| true);
+    // Deployments are filtered to those owned by a Bind9Instance — the operator has
+    // no interest in every Deployment in every watched namespace.
+    let bind9_deployments_store =
+        spawn_sharded_reflector::<Deployment, _>(&client, &scope, "Deployment", |deployment| {
+            deployment
+                .metadata
+                .owner_references
+                .as_ref()
+                .is_some_and(|owners| owners.iter().any(|owner| owner.kind == "Bind9Instance"))
+        });
+    let dnszones_store =
+        spawn_sharded_reflector::<DNSZone, _>(&client, &scope, "DNSZone", |_| true);
+    let a_records_store =
+        spawn_sharded_reflector::<ARecord, _>(&client, &scope, "ARecord", |_| true);
+    let aaaa_records_store =
+        spawn_sharded_reflector::<AAAARecord, _>(&client, &scope, "AAAARecord", |_| true);
+    let cname_records_store =
+        spawn_sharded_reflector::<CNAMERecord, _>(&client, &scope, "CNAMERecord", |_| true);
+    let txt_records_store =
+        spawn_sharded_reflector::<TXTRecord, _>(&client, &scope, "TXTRecord", |_| true);
+    let mx_records_store =
+        spawn_sharded_reflector::<MXRecord, _>(&client, &scope, "MXRecord", |_| true);
+    let ns_records_store =
+        spawn_sharded_reflector::<NSRecord, _>(&client, &scope, "NSRecord", |_| true);
+    let srv_records_store =
+        spawn_sharded_reflector::<SRVRecord, _>(&client, &scope, "SRVRecord", |_| true);
+    let caa_records_store =
+        spawn_sharded_reflector::<CAARecord, _>(&client, &scope, "CAARecord", |_| true);
+    let ptr_records_store =
+        spawn_sharded_reflector::<PTRRecord, _>(&client, &scope, "PTRRecord", |_| true);
 
     // Create the stores structure
     let stores = Stores {
@@ -679,6 +649,7 @@ async fn initialize_shared_context(client: Client) -> Result<Arc<Context>> {
         stores,
         http_client,
         metrics: Metrics::default(),
+        namespace_scope: scope,
     });
 
     info!("Shared context initialized with reflectors for all CRD types");
@@ -1326,11 +1297,24 @@ async fn run_clusterbind9provider_operator(context: Arc<Context>) -> Result<()> 
     info!("Starting ClusterBind9Provider operator");
 
     let client = context.client.clone();
+    // ClusterBind9Provider is cluster-scoped, so the PRIMARY watch is always
+    // cluster-wide. Only the owned Bind9Clusters are scoped: `.owns()` can be
+    // chained, so one controller gains one owned watch per watched namespace
+    // rather than a single cluster-wide one.
     let api = Api::<ClusterBind9Provider>::all(client.clone());
-    let bind9_cluster_api = Api::<Bind9Cluster>::all(client.clone());
 
-    Controller::new(api, default_watcher_config())
-        .owns(bind9_cluster_api, semantic_watcher_config())
+    let mut controller = Controller::new(api, default_watcher_config());
+    for target in owned_targets(&context.namespace_scope) {
+        controller = controller.owns(
+            bindy::namespace_scope::scoped_namespaced_api::<Bind9Cluster>(
+                &client,
+                target.as_deref(),
+            ),
+            semantic_watcher_config(),
+        );
+    }
+
+    controller
         .run(
             reconcile_clusterbind9provider_wrapper,
             error_policy,
@@ -1391,17 +1375,35 @@ async fn reconcile_clusterbind9provider_wrapper(
 async fn run_bind9cluster_operator(context: Arc<Context>) -> Result<()> {
     info!("Starting Bind9Cluster operator");
 
+    // Bind9Cluster is namespaced, so a `Controller` can only watch one namespace.
+    // Run one controller per watched namespace, all sharing the same reconciler
+    // and context. Cluster-wide mode yields exactly one controller, unchanged.
+    let targets = owned_targets(&context.namespace_scope);
+    futures::future::join_all(
+        targets
+            .into_iter()
+            .map(|target| run_bind9cluster_controller(context.clone(), target)),
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Run the Bind9Cluster controller for a single namespace target.
+///
+/// `target` is `None` for cluster-wide, or `Some(namespace)`.
+async fn run_bind9cluster_controller(context: Arc<Context>, target: Option<String>) {
     let client = context.client.clone();
-    let api = Api::<Bind9Cluster>::all(client.clone());
-    let instance_api = Api::<Bind9Instance>::all(client.clone());
+    let api =
+        bindy::namespace_scope::scoped_namespaced_api::<Bind9Cluster>(&client, target.as_deref());
+    let instance_api =
+        bindy::namespace_scope::scoped_namespaced_api::<Bind9Instance>(&client, target.as_deref());
 
     Controller::new(api, default_watcher_config())
         .owns(instance_api, semantic_watcher_config())
         .run(reconcile_bind9cluster_wrapper, error_policy, context)
         .for_each(|_| futures::future::ready(()))
         .await;
-
-    Ok(())
 }
 
 /// Reconcile wrapper for `Bind9Cluster`
@@ -1451,14 +1453,44 @@ async fn reconcile_bind9cluster_wrapper(
 async fn run_bind9instance_operator(context: Arc<Context>) -> Result<()> {
     info!("Starting Bind9Instance operator");
 
+    // Bind9Instance is namespaced: one controller per watched namespace, all
+    // sharing the reconciler and context. Cluster-wide mode yields exactly one.
+    let targets = owned_targets(&context.namespace_scope);
+    futures::future::join_all(
+        targets
+            .into_iter()
+            .map(|target| run_bind9instance_controller(context.clone(), target)),
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Run the Bind9Instance controller for a single namespace target.
+///
+/// `target` is `None` for cluster-wide, or `Some(namespace)`.
+#[allow(clippy::too_many_lines)]
+async fn run_bind9instance_controller(context: Arc<Context>, target: Option<String>) {
+    debug!(
+        namespace = target.as_deref().unwrap_or("<all>"),
+        "Starting Bind9Instance controller"
+    );
+
     let client = context.client.clone();
-    let api = Api::<Bind9Instance>::all(client.clone());
-    let deployment_api = Api::<Deployment>::all(client.clone());
-    let service_account_api = Api::<ServiceAccount>::all(client.clone());
-    let secret_api = Api::<Secret>::all(client.clone());
-    let configmap_api = Api::<ConfigMap>::all(client.clone());
-    let service_api = Api::<Service>::all(client.clone());
-    let _dnszone_api = Api::<DNSZone>::all(client.clone());
+    let api =
+        bindy::namespace_scope::scoped_namespaced_api::<Bind9Instance>(&client, target.as_deref());
+    let deployment_api =
+        bindy::namespace_scope::scoped_namespaced_api::<Deployment>(&client, target.as_deref());
+    let service_account_api =
+        bindy::namespace_scope::scoped_namespaced_api::<ServiceAccount>(&client, target.as_deref());
+    let secret_api =
+        bindy::namespace_scope::scoped_namespaced_api::<Secret>(&client, target.as_deref());
+    let configmap_api =
+        bindy::namespace_scope::scoped_namespaced_api::<ConfigMap>(&client, target.as_deref());
+    let service_api =
+        bindy::namespace_scope::scoped_namespaced_api::<Service>(&client, target.as_deref());
+    let _dnszone_api =
+        bindy::namespace_scope::scoped_namespaced_api::<DNSZone>(&client, target.as_deref());
 
     // Clone client and stores for the watch mapper closure
     let client_for_watch = client.clone();
@@ -1469,13 +1501,15 @@ async fn run_bind9instance_operator(context: Arc<Context>) -> Result<()> {
     // copied into the instance spec (see `crate::placement::resolve_placement`).
     // Without these watches such a change would only reach the Deployment on
     // the next 5-minute requeue.
-    let cluster_api = Api::<Bind9Cluster>::all(client.clone());
+    let cluster_api =
+        bindy::namespace_scope::scoped_namespaced_api::<Bind9Cluster>(&client, target.as_deref());
     let provider_api = Api::<ClusterBind9Provider>::all(client.clone());
     let stores_for_cluster_watch = context.stores.clone();
     let stores_for_provider_watch = context.stores.clone();
 
     // DNSZone API for status-only watcher
-    let dnszone_api = Api::<DNSZone>::all(client.clone());
+    let dnszone_api =
+        bindy::namespace_scope::scoped_namespaced_api::<DNSZone>(&client, target.as_deref());
 
     // Build the controller
     // Note: We use .owns(deployment_api) which already triggers reconciliation
@@ -1579,8 +1613,6 @@ async fn run_bind9instance_operator(context: Arc<Context>) -> Result<()> {
         .run(reconcile_bind9instance_wrapper, error_policy, context)
         .for_each(|_| futures::future::ready(()))
         .await;
-
-    Ok(())
 }
 
 /// Reconcile wrapper for `Bind9Instance`
@@ -1630,20 +1662,56 @@ async fn run_dnszone_operator(
 ) -> Result<()> {
     info!("Starting DNSZone operator");
 
+    // DNSZone is namespaced: one controller per watched namespace, all sharing the
+    // reconciler, context and zone manager. Cluster-wide mode yields exactly one.
+    let targets = owned_targets(&context.namespace_scope);
+    futures::future::join_all(
+        targets
+            .into_iter()
+            .map(|target| run_dnszone_controller(context.clone(), bind9_manager.clone(), target)),
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Run the DNSZone controller for a single namespace target.
+///
+/// `target` is `None` for cluster-wide, or `Some(namespace)`.
+async fn run_dnszone_controller(
+    context: Arc<Context>,
+    bind9_manager: Arc<Bind9Manager>,
+    target: Option<String>,
+) {
+    debug!(
+        namespace = target.as_deref().unwrap_or("<all>"),
+        "Starting DNSZone controller"
+    );
+
     let client = context.client.clone();
-    let api = Api::<DNSZone>::all(client.clone());
+    let api = bindy::namespace_scope::scoped_namespaced_api::<DNSZone>(&client, target.as_deref());
 
     // Create API clients for Bind9Instance and all record types
-    let bind9instance_api = Api::<Bind9Instance>::all(client.clone());
-    let arecord_api = Api::<ARecord>::all(client.clone());
-    let aaaarecord_api = Api::<AAAARecord>::all(client.clone());
-    let txtrecord_api = Api::<TXTRecord>::all(client.clone());
-    let cnamerecord_api = Api::<CNAMERecord>::all(client.clone());
-    let mxrecord_api = Api::<MXRecord>::all(client.clone());
-    let nsrecord_api = Api::<NSRecord>::all(client.clone());
-    let srvrecord_api = Api::<SRVRecord>::all(client.clone());
-    let caarecord_api = Api::<CAARecord>::all(client.clone());
-    let ptrrecord_api = Api::<PTRRecord>::all(client.clone());
+    let bind9instance_api =
+        bindy::namespace_scope::scoped_namespaced_api::<Bind9Instance>(&client, target.as_deref());
+    let arecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<ARecord>(&client, target.as_deref());
+    let aaaarecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<AAAARecord>(&client, target.as_deref());
+    let txtrecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<TXTRecord>(&client, target.as_deref());
+    let cnamerecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<CNAMERecord>(&client, target.as_deref());
+    let mxrecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<MXRecord>(&client, target.as_deref());
+    let nsrecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<NSRecord>(&client, target.as_deref());
+    let srvrecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<SRVRecord>(&client, target.as_deref());
+    let caarecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<CAARecord>(&client, target.as_deref());
+    let ptrrecord_api =
+        bindy::namespace_scope::scoped_namespaced_api::<PTRRecord>(&client, target.as_deref());
 
     // Clone context for watch closures
     let ctx_for_a = context.clone();
@@ -1899,8 +1967,6 @@ async fn run_dnszone_operator(
         )
         .for_each(|_| futures::future::ready(()))
         .await;
-
-    Ok(())
 }
 
 /// Reconcile wrapper for `DNSZone`

--- a/src/namespace_scope.rs
+++ b/src/namespace_scope.rs
@@ -108,6 +108,21 @@ impl NamespaceScope {
     }
 }
 
+/// Build an `Api` for a single namespace target.
+///
+/// `None` means cluster-wide (`Api::all`); `Some(ns)` means that namespace only
+/// (`Api::namespaced`). Pair with [`NamespaceScope::api_targets`].
+pub fn scoped_namespaced_api<K>(client: &kube::Client, target: Option<&str>) -> kube::Api<K>
+where
+    K: kube::Resource<Scope = kube::core::NamespaceResourceScope>,
+    K::DynamicType: Default,
+{
+    match target {
+        None => kube::Api::all(client.clone()),
+        Some(ns) => kube::Api::namespaced(client.clone(), ns),
+    }
+}
+
 #[cfg(test)]
 #[path = "namespace_scope_tests.rs"]
 mod namespace_scope_tests;

--- a/src/reconcilers/dnszone/cleanup.rs
+++ b/src/reconcilers/dnszone/cleanup.rs
@@ -156,7 +156,7 @@ pub async fn cleanup_stale_records(
     client: &Client,
     dnszone: &DNSZone,
     status_updater: &mut crate::reconcilers::status::DNSZoneStatusUpdater,
-    bind9_instances_store: &kube::runtime::reflector::Store<crate::crd::Bind9Instance>,
+    bind9_instances_store: &crate::context::MultiStore<crate::crd::Bind9Instance>,
 ) -> Result<usize> {
     use crate::bind9::records::query_dns_record;
     use crate::crd::{

--- a/src/reconcilers/dnszone/validation.rs
+++ b/src/reconcilers/dnszone/validation.rs
@@ -57,7 +57,7 @@ use crate::crd::DNSZone;
 /// if `spec.bind9_instances_from` is missing or empty.
 pub fn get_instances_from_zone(
     dnszone: &DNSZone,
-    bind9_instances_store: &kube::runtime::reflector::Store<crate::crd::Bind9Instance>,
+    bind9_instances_store: &crate::context::MultiStore<crate::crd::Bind9Instance>,
 ) -> Result<Vec<crate::crd::InstanceReference>> {
     let namespace = dnszone.namespace().unwrap_or_default();
     let name = dnszone.name_any();
@@ -212,7 +212,7 @@ pub fn instance_allows_zone_namespace(
 /// ```
 pub fn check_for_duplicate_zones(
     dnszone: &DNSZone,
-    zones_store: &kube::runtime::reflector::Store<DNSZone>,
+    zones_store: &crate::context::MultiStore<DNSZone>,
 ) -> Option<DuplicateZoneInfo> {
     let current_namespace = dnszone.namespace().unwrap_or_default();
     let current_name = dnszone.name_any();

--- a/src/reconcilers/dnszone/validation_tests.rs
+++ b/src/reconcilers/dnszone/validation_tests.rs
@@ -21,6 +21,19 @@ mod tests {
         }
     }
 
+    /// Wrap a plain reflector `Store` as a single-shard `MultiStore`.
+    ///
+    /// The production code takes a `MultiStore` so it can span several namespace
+    /// watches; a unit test only ever needs one shard, and a single shard is exactly
+    /// the cluster-wide shape.
+    fn single_shard<K>(store: kube::runtime::reflector::Store<K>) -> crate::context::MultiStore<K>
+    where
+        K: kube::Resource + Clone + 'static,
+        K::DynamicType: std::hash::Hash + Eq + Clone + std::fmt::Debug + Default,
+    {
+        crate::context::MultiStore::new(vec![store])
+    }
+
     #[test]
     fn test_filter_instances_needing_reconciliation_all_need_reconciliation() {
         let instances = vec![
@@ -145,7 +158,7 @@ mod tests {
     fn test_get_instances_no_selectors() {
         let zone = create_test_zone_with_selectors("test-zone", "default", None);
         let (store, _writer) = kube::runtime::reflector::store::<Bind9Instance>();
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -157,7 +170,7 @@ mod tests {
     fn test_get_instances_empty_selectors() {
         let zone = create_test_zone_with_selectors("test-zone", "default", Some(vec![]));
         let (store, _writer) = kube::runtime::reflector::store::<Bind9Instance>();
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -186,7 +199,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("test-zone", "default", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_ok());
         let instances = result.unwrap();
         assert_eq!(instances.len(), 1);
@@ -214,7 +227,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("test-zone", "default", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -264,7 +277,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("test-zone", "default", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_ok());
         let instances = result.unwrap();
         assert_eq!(instances.len(), 2);
@@ -319,7 +332,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("test-zone", "default", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(
             result.is_err(),
             "F-003: cross-namespace match without instance annotation must be rejected"
@@ -368,7 +381,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("tenant-zone", "tenant-a", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_ok(), "annotation opt-in must succeed: {result:?}");
         let found = result.unwrap();
         assert_eq!(found.len(), 2);
@@ -406,7 +419,7 @@ mod tests {
             Some(bind9_instances_from),
         );
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_ok(), "wildcard '*' must allow any namespace");
         assert_eq!(result.unwrap().len(), 1);
     }
@@ -441,7 +454,7 @@ mod tests {
             Some(bind9_instances_from),
         );
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(
             result.is_err(),
             "annotation that does not list the zone's namespace must reject"
@@ -468,7 +481,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("tenant-zone", "tenant-a", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &instance_store);
+        let result = get_instances_from_zone(&zone, &single_shard(instance_store.clone()));
         assert!(
             result.is_ok(),
             "same-namespace match must always succeed: {result:?}"
@@ -497,7 +510,7 @@ mod tests {
         let zone =
             create_test_zone_with_selectors("test-zone", "default", Some(bind9_instances_from));
 
-        let result = get_instances_from_zone(&zone, &store);
+        let result = get_instances_from_zone(&zone, &single_shard(store.clone()));
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -591,7 +604,7 @@ mod tests {
         writer.apply_watcher_event(&kube::runtime::watcher::Event::Apply(zone2));
 
         let current_zone = create_zone_with_status("my-zone", "team-c", "third.com", &[]);
-        let result = check_for_duplicate_zones(&current_zone, &store);
+        let result = check_for_duplicate_zones(&current_zone, &single_shard(store.clone()));
         assert!(result.is_none());
     }
 
@@ -642,7 +655,7 @@ mod tests {
         let new_zone: crate::crd::DNSZone =
             serde_json::from_value(new_zone_json).expect("Failed to create new zone");
 
-        let result = check_for_duplicate_zones(&new_zone, &store);
+        let result = check_for_duplicate_zones(&new_zone, &single_shard(store.clone()));
         assert!(result.is_some());
 
         let duplicate_info = result.unwrap();
@@ -700,7 +713,7 @@ mod tests {
         let team_b_zone: crate::crd::DNSZone =
             serde_json::from_value(team_b_zone_json).expect("Failed to create team B zone");
 
-        let result = check_for_duplicate_zones(&team_b_zone, &store);
+        let result = check_for_duplicate_zones(&team_b_zone, &single_shard(store.clone()));
         assert!(result.is_some());
 
         let duplicate_info = result.unwrap();
@@ -756,7 +769,7 @@ mod tests {
         let new_zone: crate::crd::DNSZone =
             serde_json::from_value(new_zone_json).expect("Failed to create new zone");
 
-        let result = check_for_duplicate_zones(&new_zone, &store);
+        let result = check_for_duplicate_zones(&new_zone, &single_shard(store.clone()));
         assert!(
             result.is_some(),
             "F-003: the newer zone must lose to the older zone with the same zoneName"
@@ -822,7 +835,7 @@ mod tests {
         let new_zone: crate::crd::DNSZone =
             serde_json::from_value(new_zone_json).expect("Failed to create new zone");
 
-        let result = check_for_duplicate_zones(&new_zone, &store);
+        let result = check_for_duplicate_zones(&new_zone, &single_shard(store.clone()));
         assert!(
             result.is_some(),
             "F-003: failed-state of the older zone must not unblock the newer claimant"
@@ -884,7 +897,7 @@ mod tests {
         });
         let older: crate::crd::DNSZone = serde_json::from_value(older_zone_json).unwrap();
 
-        let result = check_for_duplicate_zones(&older, &store);
+        let result = check_for_duplicate_zones(&older, &single_shard(store.clone()));
         assert!(
             result.is_none(),
             "current zone is older → it wins; result must be None"
@@ -938,7 +951,7 @@ mod tests {
         let updated_zone: crate::crd::DNSZone =
             serde_json::from_value(updated_zone_json).expect("Failed to create updated zone");
 
-        let result = check_for_duplicate_zones(&updated_zone, &store);
+        let result = check_for_duplicate_zones(&updated_zone, &single_shard(store.clone()));
         assert!(result.is_none());
     }
 
@@ -1005,7 +1018,7 @@ mod tests {
         let zone3: crate::crd::DNSZone =
             serde_json::from_value(zone3_json).expect("Failed to create zone3");
 
-        let result = check_for_duplicate_zones(&zone3, &store);
+        let result = check_for_duplicate_zones(&zone3, &single_shard(store.clone()));
         assert!(result.is_some());
 
         let duplicate_info = result.unwrap();

--- a/src/reconcilers/records/mod.rs
+++ b/src/reconcilers/records/mod.rs
@@ -102,7 +102,7 @@ async fn prepare_record_reconciliation<T, S>(
     record: &T,
     record_type: &str,
     spec_hashable: &S,
-    bind9_instances_store: &kube::runtime::reflector::Store<crate::crd::Bind9Instance>,
+    bind9_instances_store: &crate::context::MultiStore<crate::crd::Bind9Instance>,
 ) -> Result<Option<RecordReconciliationContext>>
 where
     T: Resource<DynamicType = (), Scope = k8s_openapi::NamespaceResourceScope>

--- a/src/record_operator.rs
+++ b/src/record_operator.rs
@@ -111,9 +111,43 @@ where
 {
     info!("Starting {} operator", T::KIND);
 
+    // Record kinds are namespaced: one controller per watched namespace, all sharing
+    // the reconciler, context and zone manager. Cluster-wide mode yields exactly one.
+    let targets: Vec<Option<String>> = context
+        .namespace_scope
+        .api_targets()
+        .into_iter()
+        .map(|t| t.map(ToString::to_string))
+        .collect();
+
+    futures::future::join_all(targets.into_iter().map(|target| {
+        run_generic_record_controller::<T>(context.clone(), bind9_manager.clone(), target)
+    }))
+    .await;
+
+    Ok(())
+}
+
+/// Run the record controller for one record kind in a single namespace target.
+///
+/// `target` is `None` for cluster-wide, or `Some(namespace)`.
+async fn run_generic_record_controller<T>(
+    context: Arc<Context>,
+    bind9_manager: Arc<Bind9Manager>,
+    target: Option<String>,
+) where
+    T: DnsRecordType,
+{
+    tracing::debug!(
+        kind = T::KIND,
+        namespace = target.as_deref().unwrap_or("<all>"),
+        "Starting record controller"
+    );
+
     let client = context.client.clone();
-    let api = Api::<T>::all(client.clone());
-    let dnszone_api = Api::<DNSZone>::all(client.clone());
+    let api = crate::namespace_scope::scoped_namespaced_api::<T>(&client, target.as_deref());
+    let dnszone_api =
+        crate::namespace_scope::scoped_namespaced_api::<DNSZone>(&client, target.as_deref());
 
     // Configure controller to watch for ALL changes including status updates
     let watcher_config = WatcherConfig::default().any_semantic();
@@ -156,8 +190,6 @@ where
         )
         .for_each(|_| futures::future::ready(()))
         .await;
-
-    Ok(())
 }
 
 /// Generic reconciliation wrapper with finalizer support.

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -927,6 +927,87 @@ pub(crate) fn check_zone_authorization(
     }
 }
 
+/// The DNSZone that authorizes `source_namespace` for `zone_name`, if any.
+///
+/// Same matching rules as [`check_zone_authorization`], but returns the granting
+/// object so the caller can re-verify it against the API server.
+#[must_use]
+pub(crate) fn authorizing_zone(
+    zones: &[Arc<DNSZone>],
+    zone_name: &str,
+    source_namespace: &str,
+) -> Option<Arc<DNSZone>> {
+    zones
+        .iter()
+        .find(|zone| {
+            zone.spec.zone_name == zone_name && zone_allows_source_namespace(zone, source_namespace)
+        })
+        .map(Arc::clone)
+}
+
+/// Authorize `zone_name` for `source_namespace`, re-checking the grant live.
+///
+/// [`check_zone_authorization`] reads a reflector cache, which lags the API server by
+/// the watch latency. Between that read and the server-side-apply that writes the
+/// ARecord there is a window in which a DNSZone's
+/// [`ANNOTATION_ALLOW_ZONE_NAMESPACES`] may have been tightened — the record would
+/// then be published under a grant that no longer exists (audit finding P3-4).
+///
+/// This re-reads the *specific* zone that granted access, immediately before the
+/// caller writes, shrinking the window from "watch latency" to "one API round trip".
+/// It is a narrowing, not an elimination: a true elimination needs the write itself to
+/// be conditional on the zone's `resourceVersion`, which server-side apply on a
+/// *different* object cannot express.
+///
+/// A failed live read is treated as **still authorized**: the cached grant was
+/// affirmative, and failing closed on a transient API error would drop legitimate DNS
+/// records during an API server blip. The error is logged.
+pub(crate) async fn check_zone_authorization_live(
+    client: &Client,
+    zones: &[Arc<DNSZone>],
+    zone_name: &str,
+    source_namespace: &str,
+) -> ZoneAuthz {
+    let cached = check_zone_authorization(zones, zone_name, source_namespace);
+    if cached != ZoneAuthz::Authorized {
+        return cached;
+    }
+
+    let Some(granting) = authorizing_zone(zones, zone_name, source_namespace) else {
+        return cached;
+    };
+    let (Some(ns), Some(name)) = (granting.namespace(), granting.metadata.name.clone()) else {
+        return cached;
+    };
+
+    let api: Api<DNSZone> = Api::namespaced(client.clone(), &ns);
+    match api.get(&name).await {
+        Ok(live) => {
+            if zone_allows_source_namespace(&live, source_namespace) {
+                return ZoneAuthz::Authorized;
+            }
+            warn!(
+                zone = %zone_name,
+                dnszone = %name,
+                dnszone_namespace = %ns,
+                source_namespace = %source_namespace,
+                "Zone authorization was revoked between the cached check and the write — \
+                 refusing to publish (audit finding P3-4)"
+            );
+            ZoneAuthz::Forbidden
+        }
+        Err(e) => {
+            warn!(
+                zone = %zone_name,
+                dnszone = %name,
+                error = %e,
+                "Could not re-verify zone authorization live; proceeding on the cached grant"
+            );
+            ZoneAuthz::Authorized
+        }
+    }
+}
+
 /// Resolves the IP address(es) to use for an ARecord, in priority order:
 ///
 /// 1. `bindy.firestoned.io/ip` annotation — explicit override (single IP or comma-separated list)
@@ -2437,7 +2518,14 @@ async fn reconcile(ingress: Arc<Ingress>, ctx: Arc<ScoutContext>) -> Result<Acti
     // Guard: a matching DNSZone must exist AND authorize this Ingress's
     // namespace (finding H1 — otherwise any tenant's Ingress could publish
     // into any zone Scout serves).
-    match check_zone_authorization(&ctx.zone_store.state(), &zone, &namespace) {
+    match check_zone_authorization_live(
+        &ctx.remote_client,
+        &ctx.zone_store.state(),
+        &zone,
+        &namespace,
+    )
+    .await
+    {
         ZoneAuthz::Authorized => {}
         ZoneAuthz::Forbidden => {
             warn!(
@@ -2683,7 +2771,14 @@ async fn reconcile_service(
 
     // Guard: a matching DNSZone must exist AND authorize this Service's
     // namespace (finding H1).
-    match check_zone_authorization(&ctx.zone_store.state(), &zone, &namespace) {
+    match check_zone_authorization_live(
+        &ctx.remote_client,
+        &ctx.zone_store.state(),
+        &zone,
+        &namespace,
+    )
+    .await
+    {
         ZoneAuthz::Authorized => {}
         ZoneAuthz::Forbidden => {
             warn!(service = %name, ns = %namespace, zone = %zone, "Service namespace not authorized for zone — the DNSZone must live in this namespace or set annotation {ANNOTATION_ALLOW_ZONE_NAMESPACES} to include it (or '*') — skipping");
@@ -2942,7 +3037,14 @@ async fn reconcile_httproute(
 
     // Guard: a matching DNSZone must exist AND authorize this HTTPRoute's
     // namespace (finding H1).
-    match check_zone_authorization(&ctx.zone_store.state(), &zone, &namespace) {
+    match check_zone_authorization_live(
+        &ctx.remote_client,
+        &ctx.zone_store.state(),
+        &zone,
+        &namespace,
+    )
+    .await
+    {
         ZoneAuthz::Authorized => {}
         ZoneAuthz::Forbidden => {
             warn!(httproute = %name, ns = %namespace, zone = %zone, "HTTPRoute namespace not authorized for zone — the DNSZone must live in this namespace or set annotation {ANNOTATION_ALLOW_ZONE_NAMESPACES} to include it (or '*') — skipping");
@@ -3209,7 +3311,14 @@ async fn reconcile_tlsroute(
 
     // Guard: a matching DNSZone must exist AND authorize this TLSRoute's
     // namespace (finding H1).
-    match check_zone_authorization(&ctx.zone_store.state(), &zone, &namespace) {
+    match check_zone_authorization_live(
+        &ctx.remote_client,
+        &ctx.zone_store.state(),
+        &zone,
+        &namespace,
+    )
+    .await
+    {
         ZoneAuthz::Authorized => {}
         ZoneAuthz::Forbidden => {
             warn!(tlsroute = %name, ns = %namespace, zone = %zone, "TLSRoute namespace not authorized for zone — the DNSZone must live in this namespace or set annotation {ANNOTATION_ALLOW_ZONE_NAMESPACES} to include it (or '*') — skipping");
@@ -3462,7 +3571,14 @@ async fn reconcile_tcproute(
         }
     };
 
-    match check_zone_authorization(&ctx.zone_store.state(), &zone, &namespace) {
+    match check_zone_authorization_live(
+        &ctx.remote_client,
+        &ctx.zone_store.state(),
+        &zone,
+        &namespace,
+    )
+    .await
+    {
         ZoneAuthz::Authorized => {}
         ZoneAuthz::Forbidden => {
             warn!(tcproute = %name, ns = %namespace, zone = %zone, "TCPRoute namespace not authorized for zone — the DNSZone must live in this namespace or set annotation {ANNOTATION_ALLOW_ZONE_NAMESPACES} to include it (or '*') — skipping");

--- a/src/scout_tests.rs
+++ b/src/scout_tests.rs
@@ -9,11 +9,11 @@
 mod tests {
     use crate::crd::DNSZone;
     use crate::scout::{
-        arecord_cr_name, arecord_label_selector, build_service_arecord, build_tcproute_arecord,
-        check_zone_authorization, cleanup_grace_expired, derive_record_name,
-        gateway_addresses_as_ips, gateway_parent_refs, get_record_name_annotation,
-        get_zone_annotation, has_finalizer, is_arecord_enabled, is_being_deleted,
-        is_loadbalancer_service, is_scout_opted_in, parse_gateway_service_entry,
+        arecord_cr_name, arecord_label_selector, authorizing_zone, build_service_arecord,
+        build_tcproute_arecord, check_zone_authorization, cleanup_grace_expired,
+        derive_record_name, gateway_addresses_as_ips, gateway_parent_refs,
+        get_record_name_annotation, get_zone_annotation, has_finalizer, is_arecord_enabled,
+        is_being_deleted, is_loadbalancer_service, is_scout_opted_in, parse_gateway_service_entry,
         parse_gateway_services, resolve_ip_from_service_lb_status, resolve_ips,
         resolve_ips_from_annotation, resolve_record_name, resolve_zone, service_arecord_cr_name,
         service_arecord_label_selector, service_ref_from_str, stale_arecord_label_selector,
@@ -441,6 +441,47 @@ mod tests {
         let mut annotations = BTreeMap::new();
         annotations.insert("bindy.firestoned.io/ip".to_string(), "".to_string());
         assert_eq!(resolve_ips_from_annotation(&annotations), None);
+    }
+
+    // --- P3-4: identify WHICH zone granted access, so it can be re-verified ---
+
+    #[test]
+    fn test_authorizing_zone_returns_the_granting_zone() {
+        let same_ns = zone_fixture("tenant-a", serde_json::json!({}));
+        let zones = vec![std::sync::Arc::new(same_ns)];
+        let got = authorizing_zone(&zones, "example.com", "tenant-a");
+        assert!(got.is_some(), "a same-namespace zone must be the grantor");
+    }
+
+    #[test]
+    fn test_authorizing_zone_none_when_forbidden() {
+        // Zone exists but does not authorize this source namespace — there is no
+        // grantor to re-verify, so the caller keeps the Forbidden decision.
+        let zone = zone_fixture("platform", serde_json::json!({}));
+        let zones = vec![std::sync::Arc::new(zone)];
+        assert!(authorizing_zone(&zones, "example.com", "tenant-a").is_none());
+    }
+
+    #[test]
+    fn test_authorizing_zone_none_when_zone_name_does_not_match() {
+        let zone = zone_fixture("tenant-a", serde_json::json!({}));
+        let zones = vec![std::sync::Arc::new(zone)];
+        assert!(authorizing_zone(&zones, "other.com", "tenant-a").is_none());
+    }
+
+    #[test]
+    fn test_authorizing_zone_picks_the_wildcard_grantor() {
+        let zone = zone_fixture(
+            "platform",
+            serde_json::json!({ "bindy.firestoned.io/allow-zone-namespaces": "*" }),
+        );
+        let zones = vec![std::sync::Arc::new(zone)];
+        let got = authorizing_zone(&zones, "example.com", "any-tenant");
+        assert!(
+            got.is_some(),
+            "a wildcard grant still identifies a grantor to re-verify"
+        );
+        assert_eq!(got.unwrap().metadata.namespace.as_deref(), Some("platform"));
     }
 
     // --- P3-3: make the cross-namespace wildcard grant observable ---


### PR DESCRIPTION
Implement BINDY_WATCH_NAMESPACES end to end. When set, every reflector and
controller is built with Api::namespaced per namespace, so the operator needs
only a Role/RoleBinding in each instead of a cluster-wide ClusterRoleBinding.
Unset remains cluster-wide and byte-for-byte unchanged.

Reflector stores are sharded one Store per namespace rather than merging the
per-namespace watches into a single writer. Merging is not viable:
watcher::Event::InitDone makes a reflector store replace its whole contents
with the finishing watch's buffer (kube_runtime::reflector::store does a
mem::swap), so a merged store would silently retain only the last namespace to
sync, and again on every watch reconnect. MultiStore keeps each watch's
Init/InitDone cycle confined to its own shard; cluster-wide mode is a single
shard with a pass-through.

ClusterBind9Provider is the only bindy kind with scope: Cluster, so it keeps a
single cluster-wide reflector and a slim ClusterRole. Its controller chains one
.owns() per watched namespace rather than a cluster-wide one. Scoping therefore
removes cluster-wide Secret read and workload write, but not cluster-wide access
outright.

Verified on kind: with the namespaced RBAC applied and the cluster-wide binding
removed, the operator SA is denied `get secrets` and `create deployments` both
--all-namespaces and in kube-system, while retaining both inside watched
namespaces. A three-namespace run reconciled the two watched namespaces and left
the unwatched one untouched.

Also:

- Add VAP 17/18 restricting writes on operator-generated ConfigMaps
  (app.kubernetes.io/part-of: bindy) to the operator ServiceAccount. Setting
  immutable: true was rejected: these ConfigMaps carry named.conf and are mounted
  as volumes, and the kubelet stops syncing immutable ConfigMaps, so it would turn
  every zone or ACL change into a rolling restart of the DNS servers.

- Re-read the granting DNSZone immediately before the server-side apply in Scout,
  narrowing the authorization TOCTOU window from watch latency to one API round
  trip. Fails open on a transient API error, since the cached grant was
  affirmative and failing closed would drop valid records during an API blip.

- Add `make pin-release-images` to rewrite generated release manifests to an
  @sha256 digest, failing the release if it cannot resolve one. Fix
  package-deploy-manifests to depend on docker-release; it previously needed only
  extract-version, so it never waited for the image push and could not have
  resolved a digest at all.

- Scope the bindcar API NetworkPolicy rule to the operator pod. It had no `from:`
  selector, so any pod in the cluster could reach a management API.

Tests: 1383 lib tests, make kind-integration-test green.

Signed-off-by: Erick Bourgeois <erick@jeb.ca>